### PR TITLE
Parfor lowering

### DIFF
--- a/numba_mlir/numba_mlir/decorators.py
+++ b/numba_mlir/numba_mlir/decorators.py
@@ -6,7 +6,11 @@
 Define @jit and related decorators.
 """
 
-from .mlir.compiler import mlir_compiler_pipeline, get_gpu_pipeline
+from .mlir.compiler import (
+    mlir_compiler_pipeline,
+    get_gpu_pipeline,
+    mlir_compiler_replace_parfors_pipeline,
+)
 from .mlir.vectorize import vectorize as mlir_vectorize
 from .mlir.settings import USE_MLIR
 
@@ -47,11 +51,14 @@ def mlir_jit(
     ], "gpu_use_64bit_index supported values are True/False"
     options.pop("gpu_use_64bit_index", None)
 
-    pipeline = (
-        get_gpu_pipeline(fp64_truncate, use_64bit_index)
-        if options.get("enable_gpu_pipeline", True)
-        else mlir_compiler_pipeline
-    )
+    if options.get("replace_parfors", False):
+        pipeline = mlir_compiler_replace_parfors_pipeline
+    elif options.get("enable_gpu_pipeline", True):
+        pipeline = get_gpu_pipeline(fp64_truncate, use_64bit_index)
+    else:
+        pipeline = mlir_compiler_pipeline
+
+    options.pop("replace_parfors", None)
     options.pop("enable_gpu_pipeline", None)
     options.pop(
         "access_types", None

--- a/numba_mlir/numba_mlir/decorators.py
+++ b/numba_mlir/numba_mlir/decorators.py
@@ -52,6 +52,7 @@ def mlir_jit(
     options.pop("gpu_use_64bit_index", None)
 
     if options.get("replace_parfors", False):
+        assert False, "replace_parfors is not implemented yet"
         pipeline = mlir_compiler_replace_parfors_pipeline
     elif options.get("enable_gpu_pipeline", True):
         pipeline = get_gpu_pipeline(fp64_truncate, use_64bit_index)

--- a/numba_mlir/numba_mlir/mlir/compiler.py
+++ b/numba_mlir/numba_mlir/mlir/compiler.py
@@ -107,9 +107,9 @@ class mlir_PassBuilder(orig_DefaultPassBuilder):
     def define_replace_parfors_pipeline(state, name="nopython"):
         pm = orig_DefaultPassBuilder.define_nopython_pipeline(state, name)
 
-        import numba_dpcomp.mlir.settings
+        import numba_mlir.mlir.settings
 
-        if numba_dpcomp.mlir.settings.USE_MLIR:
+        if numba_mlir.mlir.settings.USE_MLIR:
             pm.add_pass_after(MlirReplaceParfors, ParforPass)
 
         pm.finalize()

--- a/numba_mlir/numba_mlir/mlir/compiler.py
+++ b/numba_mlir/numba_mlir/mlir/compiler.py
@@ -26,6 +26,8 @@ from numba.core.typed_passes import (
     NopythonTypeInference,
     PreParforPass,
     ParforPass,
+    ParforFusionPass,
+    ParforPreLoweringPass,
     DumpParforDiagnostics,
     NopythonRewrites,
     PreLowerStripPhis,
@@ -89,6 +91,8 @@ class mlir_PassBuilder(orig_DefaultPassBuilder):
                 [
                     PreParforPass,
                     ParforPass,
+                    ParforFusionPass,
+                    ParforPreLoweringPass,
                     DumpParforDiagnostics,
                     NopythonRewrites,
                     PreLowerStripPhis,
@@ -110,7 +114,7 @@ class mlir_PassBuilder(orig_DefaultPassBuilder):
         import numba_mlir.mlir.settings
 
         if numba_mlir.mlir.settings.USE_MLIR:
-            pm.add_pass_after(MlirReplaceParfors, ParforPass)
+            pm.add_pass_after(MlirReplaceParfors, ParforPreLoweringPass)
 
         pm.finalize()
         return pm

--- a/numba_mlir/numba_mlir/mlir/passes.py
+++ b/numba_mlir/numba_mlir/mlir/passes.py
@@ -293,7 +293,7 @@ class MlirReplaceParfors(MlirBackendBase):
     _name = "mlir_replace_parfors"
 
     def __init__(self):
-        FunctionPass.__init__(self)
+        MlirBackendBase.__init__(self, push_func_stack=False)
 
     def run_pass(self, state):
         print("-=-=-=-=-=- MlirReplaceParfors -=-=-=-=-=-")

--- a/numba_mlir/numba_mlir/mlir/passes.py
+++ b/numba_mlir/numba_mlir/mlir/passes.py
@@ -289,7 +289,6 @@ def get_inner_backend(fp64_trunc, use_64bit_index):
 
 @register_pass(mutates_CFG=True, analysis_only=False)
 class MlirReplaceParfors(MlirBackendBase):
-
     _name = "mlir_replace_parfors"
 
     def __init__(self):

--- a/numba_mlir/numba_mlir/mlir/passes.py
+++ b/numba_mlir/numba_mlir/mlir/passes.py
@@ -10,6 +10,7 @@ from numba.core.compiler_machinery import FunctionPass, register_pass
 from numba.core.funcdesc import qualifying_prefix
 from numba.np.ufunc.parallel import get_thread_count
 import numba.core.types.functions
+import numba.parfors.parfor
 from contextlib import contextmanager
 
 from .settings import DUMP_IR, OPT_LEVEL, DUMP_DIAGNOSTICS
@@ -285,3 +286,84 @@ def get_inner_backend(fp64_trunc, use_64bit_index):
             return True
 
     return register_pass(mutates_CFG=True, analysis_only=False)(MlirBackendInner)
+
+@register_pass(mutates_CFG=True, analysis_only=False)
+class MlirReplaceParfors(MlirBackendBase):
+
+    _name = "mlir_replace_parfors"
+
+    def __init__(self):
+        FunctionPass.__init__(self)
+
+    def run_pass(self, state):
+        print("-=-=-=-=-=- MlirReplaceParfors -=-=-=-=-=-")
+        ir = state.func_ir
+        ir.dump()
+        module = None
+        parfor_funcs = {}
+        for _, block in ir.blocks.items():
+            for inst in block.body:
+                if not isinstance(inst, numba.parfors.parfor.Parfor):
+                    continue
+
+                inst.dump()
+                if module is None:
+                    mod_settings = {"enable_gpu_pipeline": True}
+                    module = mlir_compiler.create_module(mod_settings)
+
+                fn_name = f"parfor_impl{inst.id}"
+                arg_types = self._get_parfor_args_types(state, inst)
+                res_type = self._get_parfor_return_type(state, inst)
+
+                ctx = self._get_func_context(state)
+                ctx["fnname"] = lambda: fn_name
+                ctx["fnargs"] = lambda: arg_types
+                ctx["restype"] = lambda: res_type
+
+                mlir_compiler.lower_parfor(ctx, module, inst)
+                parfor_funcs[inst] = fn_name
+
+        if not module:
+            return False
+
+        compiled_mod = mlir_compiler.compile_module(
+            global_compiler_context, ctx, module
+        )
+
+        for inst, func_name in parfor_funcs.items():
+            func_ptr = mlir_compiler.get_function_pointer(
+                global_compiler_context, compiled_mod, func_name
+            )
+            # TODO: replace inst with call to func_ptr
+
+        return True
+
+    def _get_parfor_args_types(self, state, parfor):
+        typemap = state.typemap
+        ret = []
+        for param in parfor.params:
+            ret.append(typemap[param])
+
+        for loop in parfor.loop_nests:
+            for v in (loop.start, loop.stop, loop.step):
+                if isinstance(v, int):
+                    continue
+
+                ret.append(typemap[v.name])
+
+        return ret
+
+    def _get_parfor_return_type(self, state, parfor):
+        typemap = state.typemap
+        ret = []
+        for param in parfor.redvars:
+            ret.append(typemap[param])
+
+        count = len(ret)
+        if count == 0:
+            return types.none
+
+        if count == 1:
+            return ret[0]
+
+        return types.Tuple(ret)

--- a/numba_mlir/numba_mlir/mlir/passes.py
+++ b/numba_mlir/numba_mlir/mlir/passes.py
@@ -287,6 +287,7 @@ def get_inner_backend(fp64_trunc, use_64bit_index):
 
     return register_pass(mutates_CFG=True, analysis_only=False)(MlirBackendInner)
 
+
 @register_pass(mutates_CFG=True, analysis_only=False)
 class MlirReplaceParfors(MlirBackendBase):
     _name = "mlir_replace_parfors"

--- a/numba_mlir/numba_mlir/mlir/tests/test_basic.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_basic.py
@@ -955,3 +955,13 @@ def test_named_args_indirect():
 
     a, b, c, d = (2.0, 3.5, 4.7, 5.9)
     assert_equal(py_func2(a, b, c, d), jit_func2(a, b, c, d))
+
+def test_replace_parfor():
+    def py_func(a):
+        res = 0
+        for i in numba.prange(a):
+            res = res + i
+        return res
+
+    jit_func = njit(py_func, parallel=True, replace_parfors=True)
+    assert_equal(py_func(10), jit_func(10))

--- a/numba_mlir/numba_mlir/mlir/tests/test_basic.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_basic.py
@@ -957,11 +957,15 @@ def test_named_args_indirect():
     assert_equal(py_func2(a, b, c, d), jit_func2(a, b, c, d))
 
 def test_replace_parfor():
-    def py_func(a):
+    def py_func(c):
         res = 0
-        for i in numba.prange(a):
-            res = res + i
+        for i in numba.prange(len(c)):
+            res = res + c[i]
         return res
 
+    import numpy as np
+
+    a = np.arange(10)
+
     jit_func = njit(py_func, parallel=True, replace_parfors=True)
-    assert_equal(py_func(10), jit_func(10))
+    assert_equal(py_func(a), jit_func(a))

--- a/numba_mlir/numba_mlir/mlir/tests/test_basic.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_basic.py
@@ -960,7 +960,8 @@ def test_replace_parfor():
     def py_func(c):
         res = 0
         for i in numba.prange(len(c)):
-            res = res + c[i]
+            ind = 2 if i == 4 else i
+            res = res + c[ind]
         return res
 
     import numpy as np

--- a/numba_mlir/numba_mlir/mlir/tests/test_basic.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_basic.py
@@ -956,6 +956,8 @@ def test_named_args_indirect():
     a, b, c, d = (2.0, 3.5, 4.7, 5.9)
     assert_equal(py_func2(a, b, c, d), jit_func2(a, b, c, d))
 
+
+@pytest.mark.xfail(reason="replace_parfors is not implemented yet")
 def test_replace_parfor():
     def py_func(c):
         res = 0

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -418,12 +418,12 @@ private:
       reductionIndices[name] = static_cast<unsigned>(i);
     }
 
-    imex::util::EnvironmentRegionOp regionOp;
+    numba::util::EnvironmentRegionOp regionOp;
     if (hasDevice) {
       auto devNameAttr = builder.getStringAttr(deviceName);
       auto attr = gpu_runtime::GPURegionDescAttr::get(&ctx, devNameAttr);
       auto loc = getCurrentLoc();
-      regionOp = builder.create<imex::util::EnvironmentRegionOp>(
+      regionOp = builder.create<numba::util::EnvironmentRegionOp>(
           loc, attr, /*args*/ std::nullopt, reductionTypes);
       mlir::Block &regionBlock = regionOp.getRegion().front();
       assert(llvm::hasSingleElement(regionBlock));
@@ -444,7 +444,7 @@ private:
         index = indices.front();
       } else {
         auto resType = b.getTupleType(indices.getTypes());
-        index = b.create<imex::util::BuildTupleOp>(l, resType, indices);
+        index = b.create<numba::util::BuildTupleOp>(l, resType, indices);
       }
 
       for (auto [i, redvar] : llvm::enumerate(parforInst.attr("redvars"))) {
@@ -505,19 +505,19 @@ private:
     auto loc = getCurrentLoc();
 
     if (hasDevice) {
-      builder.create<imex::util::EnvironmentRegionYieldOp>(loc, results);
+      builder.create<numba::util::EnvironmentRegionYieldOp>(loc, results);
       results = regionOp.getResults();
       builder.setInsertionPointToEnd(block);
     }
 
     mlir::Value result;
     if (results.empty()) {
-      result = builder.create<imex::util::UndefOp>(loc, builder.getNoneType());
+      result = builder.create<numba::util::UndefOp>(loc, builder.getNoneType());
     } else if (results.size() == 1) {
       result = results.front();
     } else {
       auto resType = builder.getTupleType(results.getTypes());
-      result = builder.create<imex::util::BuildTupleOp>(loc, resType, results);
+      result = builder.create<numba::util::BuildTupleOp>(loc, resType, results);
     }
 
     builder.create<mlir::func::ReturnOp>(loc, result);
@@ -564,7 +564,7 @@ private:
     auto loop = loopBuilder.create<mlir::scf::ForOp>(
         loc, begins.front(), ends.front(), steps.front(), iterArgs,
         forBodyBuilder);
-    loop->setAttr(imex::util::attributes::getParallelName(),
+    loop->setAttr(numba::util::attributes::getParallelName(),
                   builder.getUnitAttr());
     return loop.getResults();
   }

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -427,6 +427,12 @@ private:
         index = b.create<imex::util::BuildTupleOp>(l, resType, indices);
       }
 
+      for (auto [i, redvar] : llvm::enumerate(parforInst.attr("redvars"))) {
+        assert(i < iterVars.size());
+        auto name = redvar.cast<std::string>();
+        varsMap[name] = iterVars[i];
+      }
+
       auto indexVar = parforInst.attr("index_var");
       auto indexType = getObjType(typemap(indexVar));
       index = b.create<plier::CastOp>(l, indexType, index);

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -18,6 +18,7 @@
 #include <mlir/Dialect/ControlFlow/IR/ControlFlowOps.h>
 #include <mlir/Dialect/Func/Extensions/InlinerExtension.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinOps.h>
 #include <mlir/IR/BuiltinTypes.h>
@@ -226,6 +227,7 @@ struct PlierLowerer final {
     ctx.loadDialect<gpu_runtime::GpuRuntimeDialect>();
     ctx.loadDialect<mlir::cf::ControlFlowDialect>();
     ctx.loadDialect<mlir::func::FuncDialect>();
+    ctx.loadDialect<mlir::scf::SCFDialect>();
     ctx.loadDialect<numba::ntensor::NTensorDialect>();
     ctx.loadDialect<numba::util::NumbaUtilDialect>();
     ctx.loadDialect<plier::PlierDialect>();
@@ -235,6 +237,14 @@ struct PlierLowerer final {
                            mlir::ModuleOp mod, const py::object &funcIr) {
     auto newFunc = createFunc(compilationContext, mod);
     lowerFuncBody(funcIr);
+    return newFunc;
+  }
+
+  mlir::func::FuncOp lowerParfor(const py::object &compilationContext,
+                                 mlir::ModuleOp mod,
+                                 const py::object &parforInst) {
+    auto newFunc = createFunc(compilationContext, mod);
+    lowerParforBody(parforInst);
     return newFunc;
   }
 
@@ -353,6 +363,158 @@ private:
       lowerBlock(blocks[i], irBlock.second);
 
     fixupPhis();
+  }
+
+  void lowerParforBody(py::handle parforInst) {
+    auto block = func.addEntryBlock();
+    blocks.emplace_back(block);
+    mlir::ValueRange blockArgs = block->getArguments();
+
+    auto getNextBlockArg = [&]() -> mlir::Value {
+      assert(!blockArgs.empty());
+      auto res = blockArgs.front();
+      blockArgs = blockArgs.drop_front();
+      return res;
+    };
+
+    for (auto param : parforInst.attr("params")) {
+      auto name = param.cast<std::string>();
+      varsMap[name] = getNextBlockArg();
+    }
+
+    builder.setInsertionPointToStart(block);
+    auto indexType = builder.getIndexType();
+    auto getIndexVal = [&](py::handle obj) -> mlir::Value {
+      auto loc = getCurrentLoc();
+      if (py::isinstance<py::int_>(obj)) {
+        auto val = obj.cast<int64_t>();
+        return builder.create<mlir::arith::ConstantIndexOp>(loc, val);
+      }
+
+      auto var = getNextBlockArg();
+      return builder.create<plier::CastOp>(loc, indexType, var);
+    };
+
+    llvm::SmallVector<mlir::Value, 4> begins;
+    llvm::SmallVector<mlir::Value, 4> ends;
+    llvm::SmallVector<mlir::Value, 4> steps;
+
+    for (auto loop : parforInst.attr("loop_nests")) {
+      begins.emplace_back(getIndexVal(loop.attr("start")));
+      ends.emplace_back(getIndexVal(loop.attr("stop")));
+      steps.emplace_back(getIndexVal(loop.attr("step")));
+    }
+
+    lowerBlock(block, parforInst.attr("init_block"));
+
+    llvm::SmallVector<mlir::Value> reductionInits;
+    std::unordered_map<std::string, unsigned> reductionIndices;
+    for (auto [i, redvar] : llvm::enumerate(parforInst.attr("redvars"))) {
+      auto name = redvar.cast<std::string>();
+      assert(varsMap.count(name));
+      reductionInits.emplace_back(varsMap.find(name)->second);
+      reductionIndices[name] = static_cast<unsigned>(i);
+    }
+
+    llvm::SmallVector<mlir::Value> reductionsRet(reductionInits.size());
+    auto bodyBuilder = [&](mlir::OpBuilder &b, mlir::Location l,
+                           mlir::ValueRange indices,
+                           mlir::ValueRange iterVars) -> mlir::ValueRange {
+      assert(!indices.empty());
+      mlir::Value index;
+      if (indices.size() == 1) {
+        index = indices.front();
+      } else {
+        auto resType = b.getTupleType(indices.getTypes());
+        index = b.create<imex::util::BuildTupleOp>(l, resType, indices);
+      }
+
+      auto indexVar = parforInst.attr("index_var");
+      auto indexType = getObjType(indexVar);
+      index = b.create<plier::CastOp>(l, indexType, index);
+      auto indexVarName = indexVar.attr("name").cast<std::string>();
+      varsMap[indexVarName] = index;
+
+      auto blocks = py::list(parforInst.attr("loop_body").attr("values")());
+      auto loopBlock = blocks[0];
+      for (auto inst : getBody(loopBlock)) {
+        if (py::isinstance(inst, insts.Assign)) {
+          auto target = inst.attr("target");
+          auto name = target.attr("name").cast<std::string>();
+          auto it = reductionIndices.find(name);
+          if (reductionIndices.end() != it) {
+            assert(it->second < reductionsRet.size());
+            auto val = lowerAssign(inst, target);
+            reductionsRet[it->second] = val;
+          }
+        }
+
+        lowerInst(inst);
+      }
+
+      return reductionsRet;
+    };
+
+    auto results = buildNestedParallelLoop(begins, ends, steps, reductionInits,
+                                           bodyBuilder);
+
+    mlir::Value result;
+    auto loc = getCurrentLoc();
+    if (results.empty()) {
+      result = builder.create<imex::util::UndefOp>(loc, builder.getNoneType());
+    } else if (results.size() == 1) {
+      result = results.front();
+    } else {
+      auto resType = builder.getTupleType(results.getTypes());
+      result = builder.create<imex::util::BuildTupleOp>(loc, resType, results);
+    }
+
+    builder.create<mlir::func::ReturnOp>(loc, result);
+  }
+
+  mlir::ValueRange buildNestedParallelLoop(
+      mlir::ValueRange begins, mlir::ValueRange ends, mlir::ValueRange steps,
+      mlir::ValueRange iterArgs,
+      llvm::function_ref<mlir::ValueRange(mlir::OpBuilder &, mlir::Location l,
+                                          mlir::ValueRange, mlir::ValueRange)>
+          bodyBuilder) {
+    assert(!begins.empty());
+    assert(begins.size() == ends.size());
+    assert(begins.size() == steps.size());
+
+    llvm::SmallVector<mlir::Value> indices;
+    indices.reserve(begins.size());
+    auto loc = getCurrentLoc();
+    return buildNestedParallelLoopImpl(builder, loc, begins, ends, steps,
+                                       iterArgs, bodyBuilder, indices);
+  }
+
+  mlir::ValueRange buildNestedParallelLoopImpl(
+      mlir::OpBuilder &loopBuilder, mlir::Location loc, mlir::ValueRange begins,
+      mlir::ValueRange ends, mlir::ValueRange steps, mlir::ValueRange iterArgs,
+      llvm::function_ref<mlir::ValueRange(mlir::OpBuilder &, mlir::Location l,
+                                          mlir::ValueRange, mlir::ValueRange)>
+          bodyBuilder,
+      llvm::SmallVectorImpl<mlir::Value> &indices) {
+    auto forBodyBuilder = [&](mlir::OpBuilder &b, mlir::Location l,
+                              mlir::Value index, mlir::ValueRange vars) {
+      indices.emplace_back(index);
+      mlir::ValueRange res;
+      if (llvm::hasSingleElement(begins)) {
+        res = bodyBuilder(b, l, indices, vars);
+      } else {
+        res = buildNestedParallelLoopImpl(b, l, begins.drop_front(),
+                                          ends.drop_front(), steps.drop_front(),
+                                          vars, bodyBuilder, indices);
+      }
+      b.create<mlir::scf::YieldOp>(l, res);
+    };
+    auto loop = loopBuilder.create<mlir::scf::ForOp>(
+        loc, begins.front(), ends.front(), steps.front(), iterArgs,
+        forBodyBuilder);
+    loop->setAttr(imex::util::attributes::getParallelName(),
+                  builder.getUnitAttr());
+    return loop.getResults();
   }
 
   void lowerBlock(mlir::Block *bb, py::handle irBlock) {
@@ -1056,6 +1218,18 @@ py::capsule lowerFunction(const py::object &compilationContext,
   auto &module = mod->module;
   auto func = PlierLowerer(context, mod->typeConverter)
                   .lower(compilationContext, module, funcIr);
+  return py::capsule(func.getOperation()); // no dtor, func owned by the module.
+}
+
+py::capsule lowerParfor(const pybind11::object &compilationContext,
+                        const pybind11::capsule &pyMod,
+                        const pybind11::object &parforInst) {
+  auto mod = static_cast<Module *>(pyMod);
+  auto &context = mod->context;
+  auto &module = mod->module;
+  auto func = PlierLowerer(context, mod->typeConverter)
+                  .lowerParfor(compilationContext, module, parforInst);
+  func->dump();
   return py::capsule(func.getOperation()); // no dtor, func owned by the module.
 }
 

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -404,16 +404,34 @@ private:
       steps.emplace_back(getIndexVal(loop.attr("step")));
     }
 
-    lowerBlock(block, parforInst.attr("init_block"));
+    std::string deviceName = "level_zero:gpu:0"; // TODO: get from parfor node
+    bool hasDevice = !deviceName.empty();
 
     llvm::SmallVector<mlir::Value> reductionInits;
+    llvm::SmallVector<mlir::Type> reductionTypes;
     std::unordered_map<std::string, unsigned> reductionIndices;
     for (auto [i, redvar] : llvm::enumerate(parforInst.attr("redvars"))) {
       auto name = redvar.cast<std::string>();
       assert(varsMap.count(name));
       reductionInits.emplace_back(varsMap.find(name)->second);
+      reductionTypes.emplace_back(reductionInits.back().getType());
       reductionIndices[name] = static_cast<unsigned>(i);
     }
+
+    imex::util::EnvironmentRegionOp regionOp;
+    if (hasDevice) {
+      auto devNameAttr = builder.getStringAttr(deviceName);
+      auto attr = gpu_runtime::GPURegionDescAttr::get(&ctx, devNameAttr);
+      auto loc = getCurrentLoc();
+      regionOp = builder.create<imex::util::EnvironmentRegionOp>(
+          loc, attr, /*args*/ std::nullopt, reductionTypes);
+      mlir::Block &regionBlock = regionOp.getRegion().front();
+      assert(llvm::hasSingleElement(regionBlock));
+      regionBlock.getTerminator()->erase();
+      builder.setInsertionPointToStart(&regionBlock);
+    }
+
+    lowerBlock(block, parforInst.attr("init_block"));
 
     auto bodyBuilder = [&](mlir::OpBuilder &b, mlir::Location l,
                            mlir::ValueRange indices,
@@ -439,9 +457,7 @@ private:
       auto indexVarName = indexVar.attr("name").cast<std::string>();
       varsMap[indexVarName] = index;
 
-      mlir::ValueRange reductionInitsTmp(reductionInits);
-      auto regionOp =
-          b.create<mlir::scf::ExecuteRegionOp>(l, reductionInitsTmp.getTypes());
+      auto regionOp = b.create<mlir::scf::ExecuteRegionOp>(l, reductionTypes);
       auto &region = regionOp.getRegion();
 
       auto irBlocks = getBlocks(parforInst.attr("loop_body"));
@@ -482,11 +498,17 @@ private:
       return regionOp.getResults();
     };
 
-    auto results = buildNestedParallelLoop(begins, ends, steps, reductionInits,
-                                           bodyBuilder);
+    mlir::ValueRange results = buildNestedParallelLoop(
+        begins, ends, steps, reductionInits, bodyBuilder);
+    auto loc = getCurrentLoc();
+
+    if (hasDevice) {
+      builder.create<imex::util::EnvironmentRegionYieldOp>(loc, results);
+      results = regionOp.getResults();
+      builder.setInsertionPointToEnd(block);
+    }
 
     mlir::Value result;
-    auto loc = getCurrentLoc();
     if (results.empty()) {
       result = builder.create<imex::util::UndefOp>(loc, builder.getNoneType());
     } else if (results.size() == 1) {

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -367,7 +367,6 @@ private:
 
   void lowerParforBody(py::handle parforInst) {
     auto block = func.addEntryBlock();
-    //    blocks.emplace_back(block);
     mlir::ValueRange blockArgs = block->getArguments();
 
     auto getNextBlockArg = [&]() -> mlir::Value {
@@ -443,7 +442,7 @@ private:
 
       blocks.reserve(irBlocks.size());
       mlir::OpBuilder::InsertionGuard g(b);
-      for (auto [i, irBlock] : llvm::enumerate(irBlocks)) {
+      for (auto irBlock : irBlocks) {
         auto block = b.createBlock(&region, region.end());
         blocks.emplace_back(block);
         blocksMap[irBlock.first] = block;

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -367,7 +367,7 @@ private:
 
   void lowerParforBody(py::handle parforInst) {
     auto block = func.addEntryBlock();
-    blocks.emplace_back(block);
+    //    blocks.emplace_back(block);
     mlir::ValueRange blockArgs = block->getArguments();
 
     auto getNextBlockArg = [&]() -> mlir::Value {
@@ -416,7 +416,6 @@ private:
       reductionIndices[name] = static_cast<unsigned>(i);
     }
 
-    llvm::SmallVector<mlir::Value> reductionsRet(reductionInits.size());
     auto bodyBuilder = [&](mlir::OpBuilder &b, mlir::Location l,
                            mlir::ValueRange indices,
                            mlir::ValueRange iterVars) -> mlir::ValueRange {
@@ -435,24 +434,47 @@ private:
       auto indexVarName = indexVar.attr("name").cast<std::string>();
       varsMap[indexVarName] = index;
 
-      auto blocks = py::list(parforInst.attr("loop_body").attr("values")());
-      auto loopBlock = blocks[0];
-      for (auto inst : getBody(loopBlock)) {
-        if (py::isinstance(inst, insts.Assign)) {
-          auto target = inst.attr("target");
-          auto name = target.attr("name").cast<std::string>();
-          auto it = reductionIndices.find(name);
-          if (reductionIndices.end() != it) {
-            assert(it->second < reductionsRet.size());
-            auto val = lowerAssign(inst, target);
-            reductionsRet[it->second] = val;
-          }
-        }
+      mlir::ValueRange reductionInitsTmp(reductionInits);
+      auto regionOp =
+          b.create<mlir::scf::ExecuteRegionOp>(l, reductionInitsTmp.getTypes());
+      auto &region = regionOp.getRegion();
 
-        lowerInst(inst);
+      auto irBlocks = getBlocks(parforInst.attr("loop_body"));
+
+      blocks.reserve(irBlocks.size());
+      mlir::OpBuilder::InsertionGuard g(b);
+      for (auto [i, irBlock] : llvm::enumerate(irBlocks)) {
+        auto block = b.createBlock(&region, region.end());
+        blocks.emplace_back(block);
+        blocksMap[irBlock.first] = block;
       }
 
-      return reductionsRet;
+      llvm::SmallVector<mlir::Value> reductionsRet(reductionInits.size());
+      for (auto [i, irBlock] : llvm::enumerate(irBlocks)) {
+        auto bb = blocks[i];
+        builder.setInsertionPointToEnd(bb);
+        for (auto inst : getBody(irBlock.second)) {
+          if (py::isinstance(inst, insts.Assign)) {
+            auto target = inst.attr("target");
+            auto name = target.attr("name").cast<std::string>();
+            auto it = reductionIndices.find(name);
+            if (reductionIndices.end() != it) {
+              assert(it->second < reductionsRet.size());
+              auto val = lowerAssign(inst, target);
+              reductionsRet[it->second] = val;
+            }
+          }
+
+          lowerInst(inst);
+        }
+
+        bool hasTerminator =
+            !bb->empty() && bb->back().hasTrait<mlir::OpTrait::IsTerminator>();
+        if (!hasTerminator)
+          b.create<mlir::scf::YieldOp>(l, reductionsRet);
+      }
+
+      return regionOp.getResults();
     };
 
     auto results = buildNestedParallelLoop(begins, ends, steps, reductionInits,
@@ -470,6 +492,7 @@ private:
     }
 
     builder.create<mlir::func::ReturnOp>(loc, result);
+    fixupPhis();
   }
 
   mlir::ValueRange buildNestedParallelLoop(

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -430,7 +430,7 @@ private:
       }
 
       auto indexVar = parforInst.attr("index_var");
-      auto indexType = getObjType(indexVar);
+      auto indexType = getObjType(typemap(indexVar));
       index = b.create<plier::CastOp>(l, indexType, index);
       auto indexVarName = indexVar.attr("name").cast<std::string>();
       varsMap[indexVarName] = index;

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -522,6 +522,33 @@ private:
 
     builder.create<mlir::func::ReturnOp>(loc, result);
     fixupPhis();
+
+    if (!deviceName.empty()) {
+      builder.setInsertionPointToStart(block);
+      auto newEnv = gpu_runtime::GPURegionDescAttr::get(
+          builder.getContext(), builder.getStringAttr(deviceName));
+      llvm::SmallVector<mlir::Type> newArgsTypes;
+      for (auto arg : block->getArguments()) {
+        auto argType = arg.getType();
+        newArgsTypes.emplace_back(argType);
+        auto origType = argType.dyn_cast<numba::ntensor::NTensorType>();
+        if (!origType || origType.getEnvironment())
+          continue;
+
+        auto newType = numba::ntensor::NTensorType::get(
+            builder.getContext(), origType.getShape(),
+            origType.getElementType(), newEnv, origType.getLayout());
+        arg.setType(newType);
+        auto cast = builder.create<numba::ntensor::CastOp>(getCurrentLoc(),
+                                                           origType, arg);
+        arg.replaceAllUsesExcept(cast.getResult(), cast);
+        newArgsTypes.back() = newType;
+      }
+      auto origFuncType = func.getFunctionType();
+      auto newFuncType =
+          origFuncType.clone(newArgsTypes, origFuncType.getResults());
+      func.setFunctionType(newFuncType);
+    }
   }
 
   mlir::ValueRange buildNestedParallelLoop(

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -429,9 +429,11 @@ private:
       assert(llvm::hasSingleElement(regionBlock));
       regionBlock.getTerminator()->erase();
       builder.setInsertionPointToStart(&regionBlock);
-    }
 
-    lowerBlock(block, parforInst.attr("init_block"));
+      lowerBlock(&regionBlock, parforInst.attr("init_block"));
+    } else {
+      lowerBlock(block, parforInst.attr("init_block"));
+    }
 
     auto bodyBuilder = [&](mlir::OpBuilder &b, mlir::Location l,
                            mlir::ValueRange indices,

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.hpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.hpp
@@ -21,6 +21,10 @@ pybind11::capsule lowerFunction(const pybind11::object &compilationContext,
                                 const pybind11::capsule &pyMod,
                                 const pybind11::object &funcIr);
 
+pybind11::capsule lowerParfor(const pybind11::object &compilationContext,
+                              const pybind11::capsule &pyMod,
+                              const pybind11::object &parforInst);
+
 pybind11::capsule compileModule(const pybind11::capsule &compiler,
                                 const pybind11::object &compilationContext,
                                 const pybind11::capsule &pyMod);

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/PyModule.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/PyModule.cpp
@@ -36,6 +36,7 @@ PYBIND11_MODULE(mlir_compiler, m) {
   m.def("init_compiler", &initCompiler, "No docs");
   m.def("create_module", &createModule, "No docs");
   m.def("lower_function", &lowerFunction, "No docs");
+  m.def("lower_parfor", &lowerParfor, "No docs");
   m.def("compile_module", &compileModule, "No docs");
   m.def("register_symbol", &registerSymbol, "No docs");
   m.def("get_function_pointer", &getFunctionPointer, "No docs");


### PR DESCRIPTION
Add API to outline parfor nodes as separate MLIR functions.
Testing: `pytest -vv --capture=tee-sys -rXF "numba_mlir/mlir/tests/test_basic.py::test_replace_parfor"`
