### PR TITLE
Update C++ compilers handling in scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,9 +51,9 @@ jobs:
           use-only-tar-bz2: true
           run-post: false
 
-      - name: Install CMake and Ninja
+      - name: Setup Environment
         run: |
-          conda env update -n test -f $env:CORE_ENV_FILE --prune
+          conda env create -n test-env --file $env:CORE_ENV_FILE
           conda list
 
       - name: Setup Cache Vars
@@ -114,6 +114,7 @@ jobs:
       - name: Download and Build Level-Zero
         if: steps.cache-level-zero.outputs.cache-hit != 'true'
         run: |
+          conda activate test-env
           cd $env:WORKSPACE
           mkdir -ea 0 -p level-zero
           pushd level-zero
@@ -144,6 +145,7 @@ jobs:
         if: steps.cache-llvm-mlir.outputs.cache-hit != 'true'
         timeout-minutes: 420
         run: |
+          conda activate test-env
           cd $env:WORKSPACE
           mkdir -ea 0 -p llvm-mlir
           pushd llvm-mlir
@@ -391,7 +393,7 @@ jobs:
       - name: Add conda to system path
         run: echo $CONDA/bin >> $GITHUB_PATH
 
-      - name: Install CMake and Ninja
+      - name: Setup Environment
         run: |
           conda env update -n base -f $CORE_ENV_FILE --prune
           conda list

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,11 +58,6 @@ jobs:
           activate-environment: test-env
           environment-file: ${{ env.CORE_ENV_FILE }}
 
-      - name: Setup Environment
-        run: |
-          # conda env update -n test -f $env:CORE_ENV_FILE --prune
-          conda list
-
       - name: Setup Cache Vars
         run: |
           $sha = (cat "$env:GITHUB_WORKSPACE\$env:LLVM_SHA_FILE")

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -493,6 +493,7 @@ jobs:
           git checkout $LLVM_SHA || exit 1
           mkdir _build || exit 1
           cd _build || exit 1
+          conda activate base
           export CC=$CONDA_PREFIX/bin/x86_64-conda-linux-gnu-cc
           export CXX=$CONDA_PREFIX/bin/x86_64-conda-linux-gnu-c++
           cmake ../llvm                                                    \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,11 +54,11 @@ jobs:
           environment-file: ${{ env.CORE_ENV_FILE }}
 
       - name: Setup Environment
+        shell: powershell
         run: |
           # conda env update -n test -f $env:CORE_ENV_FILE --prune
+          conda init powershell
           conda list
-          cd "$env:CONDA_PREFIX\etc\conda\activate.d"
-          ls
 
       - name: Setup Cache Vars
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,6 +153,8 @@ jobs:
           git checkout $env:LLVM_SHA
           mkdir _build
           cd _build
+          $env:CXX="cl.exe"
+          $env:CC="cl.exe"
           cmake ../llvm                                                    `
             -GNinja                                                        `
             -DCMAKE_BUILD_TYPE=Release                                     `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,11 @@ env:
   LEVEL_ZERO_VER: v1.6.2
   TBB_URL_PREFIX: https://github.com/oneapi-src/oneTBB/releases/download/
   LLVM_SHA_FILE: llvm-sha.txt
-  CORE_ENV_FILE: scripts/core-env.yml
 
 jobs:
   build_win:
+    env:
+      CORE_ENV_FILE: scripts/core-env-win.yml
     name: Builds Numba-MLIR core on Windows
     runs-on: windows-latest
     timeout-minutes: 450
@@ -357,6 +358,8 @@ jobs:
 
 
   build_linux:
+    env:
+      CORE_ENV_FILE: scripts/core-env-linux.yml
     name: Builds Numba-MLIR core on Linux
     runs-on: ubuntu-latest
     timeout-minutes: 450

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ jobs:
     timeout-minutes: 450
 
     steps:
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          vsversion : 2017
+
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,6 +153,7 @@ jobs:
           git checkout $env:LLVM_SHA
           mkdir _build
           cd _build
+          conda deactivate
           conda activate test
           $env:CXX="cl.exe"
           $env:CC="cl.exe"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,6 +146,7 @@ jobs:
         timeout-minutes: 420
         run: |
           conda activate test-env
+          conda list
           cd $env:WORKSPACE
           mkdir -ea 0 -p llvm-mlir
           pushd llvm-mlir
@@ -155,9 +156,6 @@ jobs:
           git checkout $env:LLVM_SHA
           mkdir _build
           cd _build
-          conda deactivate
-          conda activate test
-          conda list
           $env:CXX="cl.exe"
           $env:CC="cl.exe"
           cmake ../llvm                                                    `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -422,7 +422,7 @@ jobs:
         id: cache-llvm-mlir
         uses: actions/cache@v3
         env:
-          LLVM_CACHE_NUMBER: 1  # Increase to reset cache
+          LLVM_CACHE_NUMBER: 2  # Increase to reset cache
         with:
           path: |
             /home/runner/work/llvm-mlir/_mlir_install/**
@@ -603,7 +603,7 @@ jobs:
         id: cache-llvm-mlir
         uses: actions/cache@v3
         env:
-          LLVM_CACHE_NUMBER: 1  # Increase to reset cache
+          LLVM_CACHE_NUMBER: 2  # Increase to reset cache
         with:
           path: |
             /home/runner/work/llvm-mlir/_mlir_install/**

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -493,6 +493,8 @@ jobs:
           git checkout $LLVM_SHA || exit 1
           mkdir _build || exit 1
           cd _build || exit 1
+          export CC=$CONDA_PREFIX/bin/x86_64-conda-linux-gnu-cc
+          export CXX=$CONDA_PREFIX/bin/x86_64-conda-linux-gnu-c++
           cmake ../llvm                                                    \
             -GNinja                                                        \
             -DCMAKE_BUILD_TYPE=Release                                     \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install CMake and Ninja
         run: |
-          conda env update -n test -f $env:CORE_ENV_FILE --prune -c conda-forge --override-channels
+          conda env update -n test -f $env:CORE_ENV_FILE --prune
           conda list
 
       - name: Setup Cache Vars
@@ -394,7 +394,7 @@ jobs:
 
       - name: Install CMake and Ninja
         run: |
-          conda env update -n base -f $CORE_ENV_FILE --prune -c conda-forge --override-channels
+          conda env update -n base -f $CORE_ENV_FILE --prune
           conda list
 
       - name: Setup Cache Vars

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,6 @@ jobs:
     timeout-minutes: 450
 
     steps:
-      - uses: ilammy/msvc-dev-cmd@v1
-
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,9 +58,6 @@ jobs:
         run: |
           # conda env update -n test -f $env:CORE_ENV_FILE --prune
           conda list
-          conda deactivate
-          conda activate test-env
-          conda list
 
       - name: Setup Cache Vars
         run: |
@@ -120,6 +117,7 @@ jobs:
       - name: Download and Build Level-Zero
         if: steps.cache-level-zero.outputs.cache-hit != 'true'
         run: |
+          "$env:CONDA_PREFIX\etc\conda\activate.d\vs2017_compiler_vars.bat"
           cd $env:WORKSPACE
           mkdir -ea 0 -p level-zero
           pushd level-zero
@@ -150,6 +148,7 @@ jobs:
         if: steps.cache-llvm-mlir.outputs.cache-hit != 'true'
         timeout-minutes: 420
         run: |
+          "$env:CONDA_PREFIX\etc\conda\activate.d\vs2017_compiler_vars.bat"
           conda list
           cd $env:WORKSPACE
           mkdir -ea 0 -p llvm-mlir
@@ -182,6 +181,7 @@ jobs:
 
       - name: Build Numba-MLIR
         run: |
+          "$env:CONDA_PREFIX\etc\conda\activate.d\vs2017_compiler_vars.bat"
           $external_lit="$env:GITHUB_WORKSPACE\scripts\runlit.py"
           mkdir -p _build
           cd _build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
           auto-update-conda: true
           use-only-tar-bz2: true
           run-post: false
+          activate-environment: test-env
           environment-file: ${{ env.CORE_ENV_FILE }}
 
       - name: Setup Environment

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,6 +153,7 @@ jobs:
           git checkout $env:LLVM_SHA
           mkdir _build
           cd _build
+          conda activate test
           $env:CXX="cl.exe"
           $env:CC="cl.exe"
           cmake ../llvm                                                    `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
     timeout-minutes: 450
 
     steps:
+      - uses: ilammy/msvc-dev-cmd@v1
+
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,14 +21,10 @@ jobs:
     env:
       CORE_ENV_FILE: scripts/core-env-win.yml
     name: Builds Numba-MLIR core on Windows
-    runs-on: windows-latest
+    runs-on: windows-2016
     timeout-minutes: 450
 
     steps:
-      - uses: ilammy/msvc-dev-cmd@v1
-        with:
-          vsversion : "2017"
-
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
         with:
@@ -209,7 +205,7 @@ jobs:
 
   build_win_python:
     name: Builds Numba-MLIR on Windows
-    runs-on: windows-latest
+    runs-on: windows-2016
     timeout-minutes: 450
     needs: build_win
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,9 @@ jobs:
         run: |
           # conda env update -n test -f $env:CORE_ENV_FILE --prune
           conda list
+          conda deactivate
+          conda activate test-env
+          conda list
 
       - name: Setup Cache Vars
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,7 @@ jobs:
           cd _build
           conda deactivate
           conda activate test
+          conda list
           $env:CXX="cl.exe"
           $env:CC="cl.exe"
           cmake ../llvm                                                    `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,8 +56,9 @@ jobs:
       - name: Setup Environment
         run: |
           # conda env update -n test -f $env:CORE_ENV_FILE --prune
-          conda init powershell
           conda list
+          cd "$env:CONDA_PREFIX\etc\conda\activate.d"
+          ls
 
       - name: Setup Cache Vars
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,6 @@ jobs:
       - name: Download and Build Level-Zero
         if: steps.cache-level-zero.outputs.cache-hit != 'true'
         run: |
-          "$env:CONDA_PREFIX\etc\conda\activate.d\vs2017_compiler_vars.bat"
           cd $env:WORKSPACE
           mkdir -ea 0 -p level-zero
           pushd level-zero
@@ -148,7 +147,6 @@ jobs:
         if: steps.cache-llvm-mlir.outputs.cache-hit != 'true'
         timeout-minutes: 420
         run: |
-          "$env:CONDA_PREFIX\etc\conda\activate.d\vs2017_compiler_vars.bat"
           conda list
           cd $env:WORKSPACE
           mkdir -ea 0 -p llvm-mlir
@@ -181,7 +179,6 @@ jobs:
 
       - name: Build Numba-MLIR
         run: |
-          "$env:CONDA_PREFIX\etc\conda\activate.d\vs2017_compiler_vars.bat"
           $external_lit="$env:GITHUB_WORKSPACE\scripts\runlit.py"
           mkdir -p _build
           cd _build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,6 +141,7 @@ jobs:
           popd
 
       - name: Build LLVM-MLIR
+        shell: powershell
         if: steps.cache-llvm-mlir.outputs.cache-hit != 'true'
         timeout-minutes: 420
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Setup Environment
         run: |
-          conda env create -n test-env --file $env:CORE_ENV_FILE
+          conda env update -n test -f $env:CORE_ENV_FILE --prune
           conda list
 
       - name: Setup Cache Vars
@@ -114,7 +114,6 @@ jobs:
       - name: Download and Build Level-Zero
         if: steps.cache-level-zero.outputs.cache-hit != 'true'
         run: |
-          conda activate test-env
           cd $env:WORKSPACE
           mkdir -ea 0 -p level-zero
           pushd level-zero
@@ -145,7 +144,6 @@ jobs:
         if: steps.cache-llvm-mlir.outputs.cache-hit != 'true'
         timeout-minutes: 420
         run: |
-          conda activate test-env
           conda list
           cd $env:WORKSPACE
           mkdir -ea 0 -p llvm-mlir

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       CORE_ENV_FILE: scripts/core-env-win.yml
     name: Builds Numba-MLIR core on Windows
-    runs-on: windows-2016
+    runs-on: windows-2019
     timeout-minutes: 450
 
     steps:
@@ -205,7 +205,7 @@ jobs:
 
   build_win_python:
     name: Builds Numba-MLIR on Windows
-    runs-on: windows-2016
+    runs-on: windows-2019
     timeout-minutes: 450
     needs: build_win
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: ilammy/msvc-dev-cmd@v1
         with:
-          vsversion : 2017
+          vsversion : "2017"
 
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install CMake and Ninja
         run: |
-          conda env update -n test -f $env:CORE_ENV_FILE --prune
+          conda env update -n test -f $env:CORE_ENV_FILE --prune -c conda-forge --override-channels
           conda list
 
       - name: Setup Cache Vars
@@ -394,7 +394,7 @@ jobs:
 
       - name: Install CMake and Ninja
         run: |
-          conda env update -n base -f $CORE_ENV_FILE --prune
+          conda env update -n base -f $CORE_ENV_FILE --prune -c conda-forge --override-channels
           conda list
 
       - name: Setup Cache Vars

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,11 @@ jobs:
           auto-update-conda: true
           use-only-tar-bz2: true
           run-post: false
+          environment-file: ${{ env.CORE_ENV_FILE }}
 
       - name: Setup Environment
         run: |
-          conda env update -n test -f $env:CORE_ENV_FILE --prune
+          # conda env update -n test -f $env:CORE_ENV_FILE --prune
           conda list
 
       - name: Setup Cache Vars

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,6 +225,10 @@ jobs:
             python: "3.9"
 
     steps:
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          vsversion : "2019"
+
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -493,7 +493,7 @@ jobs:
           git checkout $LLVM_SHA || exit 1
           mkdir _build || exit 1
           cd _build || exit 1
-          conda activate base
+          source activate base
           export CC=$CONDA_PREFIX/bin/x86_64-conda-linux-gnu-cc
           export CXX=$CONDA_PREFIX/bin/x86_64-conda-linux-gnu-c++
           cmake ../llvm                                                    \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,8 @@ jobs:
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2
         with:
+          auto-activate-base: true
+          activate-environment: ""
           auto-update-conda: true
           use-only-tar-bz2: true
           run-post: false
@@ -228,6 +230,8 @@ jobs:
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2
         with:
+          auto-activate-base: true
+          activate-environment: ""
           auto-update-conda: true
           use-only-tar-bz2: true
           run-post: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,6 @@ jobs:
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-activate-base: true
-          activate-environment: ""
           auto-update-conda: true
           use-only-tar-bz2: true
           run-post: false
@@ -230,8 +228,6 @@ jobs:
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-activate-base: true
-          activate-environment: ""
           auto-update-conda: true
           use-only-tar-bz2: true
           run-post: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,6 +331,7 @@ jobs:
           mkdir numba_mlir_conda
           pushd numba_mlir_conda
           conda activate test-env
+          Rename-Item -Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\vsdevcmd\ext\vsicvars.bat" -NewName "vsicvars.bat.bak"
           $env:TBB_PATH=(Resolve-Path "$env:WORKSPACE/tbb/oneapi-tbb-$env:TBB_VER")
           $env:LEVEL_ZERO_DIR=(Resolve-Path "$env:WORKSPACE/level-zero/level-zero/level_zero_install")
           $env:LEVEL_ZERO_VERSION_CHECK_OFF="1"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
         id: cache-llvm-mlir
         uses: actions/cache@v3
         env:
-          LLVM_CACHE_NUMBER: 1  # Increase to reset cache
+          LLVM_CACHE_NUMBER: 2  # Increase to reset cache
         with:
           path: |
             D:\a\numba-mlir\llvm-mlir\_mlir_install\**
@@ -264,7 +264,7 @@ jobs:
         id: cache-llvm-mlir
         uses: actions/cache@v3
         env:
-          LLVM_CACHE_NUMBER: 1  # Increase to reset cache
+          LLVM_CACHE_NUMBER: 2  # Increase to reset cache
         with:
           path: |
             D:\a\numba-mlir\llvm-mlir\_mlir_install\**

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2
         with:
+          miniconda-version: "latest"
           auto-update-conda: true
           use-only-tar-bz2: true
           run-post: false
@@ -54,10 +55,8 @@ jobs:
           environment-file: ${{ env.CORE_ENV_FILE }}
 
       - name: Setup Environment
-        shell: powershell
         run: |
           # conda env update -n test -f $env:CORE_ENV_FILE --prune
-          conda init powershell
           conda list
 
       - name: Setup Cache Vars
@@ -145,7 +144,6 @@ jobs:
           popd
 
       - name: Build LLVM-MLIR
-        shell: powershell
         if: steps.cache-llvm-mlir.outputs.cache-hit != 'true'
         timeout-minutes: 420
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ jobs:
     timeout-minutes: 450
 
     steps:
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          vsversion : "2019"
+
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,6 @@ jobs:
             -DLLVM_ENABLE_PROJECTS=mlir                                    `
             -DLLVM_ENABLE_ASSERTIONS=ON                                    `
             -DLLVM_ENABLE_RTTI=ON                                          `
-            -DLLVM_USE_LINKER=gold                                         `
             -DLLVM_INSTALL_UTILS=ON                                        `
             -DLLVM_TARGETS_TO_BUILD=X86                                    `
             -DLLVM_ENABLE_BINDINGS=OFF                                     `
@@ -502,7 +501,6 @@ jobs:
             -DLLVM_ENABLE_PROJECTS=mlir                                    \
             -DLLVM_ENABLE_ASSERTIONS=ON                                    \
             -DLLVM_ENABLE_RTTI=ON                                          \
-            -DLLVM_USE_LINKER=gold                                         \
             -DLLVM_INSTALL_UTILS=ON                                        \
             -DLLVM_TARGETS_TO_BUILD=X86                                    \
             -DLLVM_ENABLE_BINDINGS=OFF                                     \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,8 @@ jobs:
         run: |
           # conda env update -n test -f $env:CORE_ENV_FILE --prune
           conda list
+          cd "$env:CONDA_PREFIX\etc\conda\"
+          ls
 
       - name: Setup Cache Vars
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,9 +56,8 @@ jobs:
       - name: Setup Environment
         run: |
           # conda env update -n test -f $env:CORE_ENV_FILE --prune
+          conda init powershell
           conda list
-          cd "$env:CONDA_PREFIX\etc\conda\"
-          ls
 
       - name: Setup Cache Vars
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,6 @@ jobs:
     timeout-minutes: 450
 
     steps:
-      - uses: ilammy/msvc-dev-cmd@v1
-
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
         with:
@@ -219,8 +217,6 @@ jobs:
             python: "3.9"
 
     steps:
-      - uses: ilammy/msvc-dev-cmd@v1
-
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
         with:

--- a/numba_mlir/conda-recipe/conda_build_config.yaml
+++ b/numba_mlir/conda-recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+cxx_compiler:
+  - vs2019                     # [win]

--- a/numba_mlir/conda-recipe/conda_build_config.yaml
+++ b/numba_mlir/conda-recipe/conda_build_config.yaml
@@ -1,2 +1,2 @@
 cxx_compiler:
-  - vs2019                     # [win]
+  - vs2019  # [win]

--- a/numba_mlir/conda-recipe/meta.yaml
+++ b/numba_mlir/conda-recipe/meta.yaml
@@ -12,6 +12,7 @@ build:
         - LLVM_PATH
         - LEVEL_ZERO_DIR
         - LEVEL_ZERO_VERSION_CHECK_OFF
+        - ClearDevCommandPromptEnvVars=false # [win]
 
 requirements:
     build:

--- a/numba_mlir/conda-recipe/meta.yaml
+++ b/numba_mlir/conda-recipe/meta.yaml
@@ -12,7 +12,6 @@ build:
         - LLVM_PATH
         - LEVEL_ZERO_DIR
         - LEVEL_ZERO_VERSION_CHECK_OFF
-        - VSCMD_DEBUG=3
 
 requirements:
     build:

--- a/numba_mlir/conda-recipe/meta.yaml
+++ b/numba_mlir/conda-recipe/meta.yaml
@@ -12,6 +12,7 @@ build:
         - LLVM_PATH
         - LEVEL_ZERO_DIR
         - LEVEL_ZERO_VERSION_CHECK_OFF
+        - VSCMD_DEBUG=3
 
 requirements:
     build:

--- a/numba_mlir/conda-recipe/meta.yaml
+++ b/numba_mlir/conda-recipe/meta.yaml
@@ -12,7 +12,6 @@ build:
         - LLVM_PATH
         - LEVEL_ZERO_DIR
         - LEVEL_ZERO_VERSION_CHECK_OFF
-        - ClearDevCommandPromptEnvVars=false # [win]
 
 requirements:
     build:

--- a/numba_mlir/conda-recipe/meta.yaml
+++ b/numba_mlir/conda-recipe/meta.yaml
@@ -15,6 +15,7 @@ build:
 
 requirements:
     build:
+        - {{ compiler('cxx') }}
         - python
         - ninja
         - cmake

--- a/scripts/core-env-linux.yml
+++ b/scripts/core-env-linux.yml
@@ -1,0 +1,11 @@
+name: dev
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - python=3.10
+  - cmake
+  - ninja
+  - lit
+  - zlib
+  - gxx_linux-64

--- a/scripts/core-env-linux.yml
+++ b/scripts/core-env-linux.yml
@@ -1,6 +1,7 @@
 name: dev
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - python=3.10
   - cmake

--- a/scripts/core-env-linux.yml
+++ b/scripts/core-env-linux.yml
@@ -1,6 +1,5 @@
 name: dev
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - python=3.10

--- a/scripts/core-env-win.yml
+++ b/scripts/core-env-win.yml
@@ -8,4 +8,4 @@ dependencies:
   - ninja
   - lit
   - zlib
-  - compilers
+  - vs2019_win-64

--- a/scripts/core-env-win.yml
+++ b/scripts/core-env-win.yml
@@ -8,4 +8,4 @@ dependencies:
   - ninja
   - lit
   - zlib
-  - vs2017_win-64
+  - vs2019_win-64

--- a/scripts/core-env-win.yml
+++ b/scripts/core-env-win.yml
@@ -1,6 +1,7 @@
 name: dev
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - python=3.10
   - cmake

--- a/scripts/core-env-win.yml
+++ b/scripts/core-env-win.yml
@@ -1,6 +1,5 @@
 name: dev
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - python=3.10

--- a/scripts/core-env-win.yml
+++ b/scripts/core-env-win.yml
@@ -8,4 +8,4 @@ dependencies:
   - ninja
   - lit
   - zlib
-  - vs2019_win-64
+  - vs2017_win-64

--- a/scripts/core-env.yml
+++ b/scripts/core-env.yml
@@ -8,3 +8,4 @@ dependencies:
   - ninja
   - lit
   - zlib
+  - compilers


### PR DESCRIPTION
* Add compilers to env ymls
* Add `{{ compiler('cxx') }}` to `meta.yaml`
* Pin windows compiler to vs2019
* Add workarond with `vsicvars.bat` renaming, otherwise vs2019 env will refuse to activate from conda build