### PR TITLE
Improve constants lowering

### DIFF
--- a/numba_mlir/numba_mlir/mlir/passes.py
+++ b/numba_mlir/numba_mlir/mlir/passes.py
@@ -140,6 +140,7 @@ class MlirBackendBase(FunctionPass):
             lambda: get_thread_count() if state.flags.auto_parallel.enabled else 0
         )
         ctx["opt_level"] = lambda: OPT_LEVEL
+        ctx["globals"] = lambda: state.func_id.func.__globals__
         return ctx
 
 

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
@@ -244,6 +244,18 @@ def test_broadcast(a, b):
     assert_equal(py_func(a, b), jit_func(a, b))
 
 
+@parametrize_function_variants(
+    "py_func",
+    [
+        "lambda: np.pi",
+        "lambda: np.e",
+    ],
+)
+def test_np_const(py_func):
+    jit_func = njit(py_func)
+    assert_equal(py_func(), jit_func())
+
+
 def test_staticgetitem():
     def py_func(a):
         return a[1]

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -536,9 +536,15 @@ private:
                         llvm::SmallVectorImpl<llvm::StringRef> &names) {
     if (auto global = val.getDefiningOp<plier::GlobalOp>()) {
       std::string name = global.getName().str();
+      if (!globals.contains(name.c_str()))
+        return std::nullopt;
+
       py::object attr = globals[name.c_str()];
       while (!names.empty()) {
         name = names.pop_back_val().str();
+        if (!py::hasattr(attr, name.c_str()))
+          return std::nullopt;
+
         attr = attr.attr(name.c_str());
       }
 


### PR DESCRIPTION
* Lower module constants like `math.pi` during frontend lowering
* Remove hardcoded lowering for `math.pi` and `math.e` (`numpy.pi` and `numpy.e` wasn't even supported)
* Ideally we should lower them during lowering passes instead of frontend, but I don't have a good design for this at the moment