### PR TITLE
Fix math uplifting

### DIFF
--- a/mlir/lib/Transforms/UpliftMath.cpp
+++ b/mlir/lib/Transforms/UpliftMath.cpp
@@ -50,8 +50,11 @@ struct UpliftMathCalls : public mlir::OpRewritePattern<mlir::func::CallOp> {
         llvm::any_of(op.getResultTypes(), isNotValidType))
       return mlir::failure();
 
-    llvm::StringRef funcNameF =
+    llvm::StringRef funcNameFPref =
         (funcName.front() == 'f' ? funcName.drop_front() : llvm::StringRef{});
+
+    llvm::StringRef funcNameFPost =
+        (funcName.back() == 'f' ? funcName.drop_back() : llvm::StringRef{});
 
     using func_t = mlir::Operation *(*)(mlir::OpBuilder &, mlir::Location,
                                         mlir::ValueRange);
@@ -69,7 +72,7 @@ struct UpliftMathCalls : public mlir::OpRewritePattern<mlir::func::CallOp> {
 
     for (auto &handler : handlers) {
       auto name = handler.first;
-      if (name == funcName || name == funcNameF) {
+      if (name == funcName || name == funcNameFPref || name == funcNameFPost) {
         auto res = handler.second(rewriter, op.getLoc(), op.getOperands());
         if (!res)
           return mlir::failure();

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
@@ -546,6 +546,19 @@ def test_sum_add2():
     assert_equal(py_func(arr1, arr2, arr3), jit_func(arr1, arr2, arr3))
 
 
+@pytest.mark.parametrize("arr", _test_arrays)
+@pytest.mark.parametrize("name", ["sqrt", "log", "exp", "sin", "cos"])
+def test_math_uplifting1(arr, name):
+    py_func = eval(f"lambda a: np.{name}(a)")
+
+    with print_pass_ir([], ["UpliftMathPass"]):
+        jit_func = njit(py_func)
+
+        assert_equal(py_func(arr), jit_func(arr))
+        ir = get_print_buffer()
+        assert ir.count(f"math.{name}") == 1, ir
+
+
 _scalars = [1, 2.5, 3.6 + 4.7j]
 _complex_arrays = [
     np.array([1, 2, 3]),

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
@@ -554,7 +554,7 @@ def test_math_uplifting1(arr, name):
     with print_pass_ir([], ["UpliftMathPass"]):
         jit_func = njit(py_func)
 
-        assert_equal(py_func(arr), jit_func(arr))
+        assert_allclose(py_func(arr), jit_func(arr), rtol=1e-7, atol=1e-7)
         ir = get_print_buffer()
         assert ir.count(f"math.{name}") == 1, ir
 


### PR DESCRIPTION
Accept `sqrtf` type of names in addition to `fsqrt`.

