### PR TITLE
Sycl gpu runtime cleanup

### DIFF
--- a/numba_mlir/numba_mlir/mlir/dpctl_interop.py
+++ b/numba_mlir/numba_mlir/mlir/dpctl_interop.py
@@ -153,7 +153,7 @@ if _is_dpctl_available:
             dtype = numpy_support.from_dtype(val.dtype)
         except NotImplementedError:
             raise ValueError("Unsupported array dtype: %s" % (val.dtype,))
-        layout = "C"  # TODO: infer layout
+        layout = numpy_support.map_layout(val)
         readonly = False
         filter_string = _get_filter_string(val)
         assert filter_string is not None

--- a/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
@@ -1177,6 +1177,7 @@ def test_cfd_reshape():
 
 @pytest.mark.smoke
 @require_dpctl
+@skip_opencl_reductions
 @pytest.mark.parametrize("size", [1, 7, 16, 64, 65, 256, 512, 1024 * 1024])
 def test_cfd_reduce1(size):
     if size == 1:
@@ -1207,6 +1208,7 @@ _shapes = (1, 7, 16, 25, 64, 65)
 
 
 @require_dpctl
+@skip_opencl_reductions
 @parametrize_function_variants(
     "py_func",
     [

--- a/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
@@ -943,7 +943,7 @@ def _from_host(arr, buffer):
         obj=arr,
         dtype=arr.dtype,
         device=_def_device,
-        copy=None,
+        copy=True,
         usm_type=buffer,
         sycl_queue=None,
         order=order,

--- a/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
@@ -933,9 +933,8 @@ def test_group_func(group_op, global_size, local_size, dtype):
 
 
 def _from_host(arr, buffer):
-    ret = dpt.usm_ndarray(arr.shape, dtype=arr.dtype, buffer=buffer).to_device(
-        _def_device
-    )
+    ret = dpt.usm_ndarray(arr.shape, dtype=arr.dtype, buffer=buffer)
+    ret = ret.to_device(_def_device)
     ret.usm_data.copy_from_host(arr.reshape((-1)).view("|u1"))
     return ret
 
@@ -1167,7 +1166,6 @@ def test_cfd_reshape():
 
 @pytest.mark.smoke
 @require_dpctl
-@skip_opencl_reductions
 @pytest.mark.parametrize("size", [1, 7, 16, 64, 65, 256, 512, 1024 * 1024])
 def test_cfd_reduce1(size):
     if size == 1:
@@ -1198,7 +1196,6 @@ _shapes = (1, 7, 16, 25, 64, 65)
 
 
 @require_dpctl
-@skip_opencl_reductions
 @parametrize_function_variants(
     "py_func",
     [

--- a/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
@@ -926,7 +926,8 @@ def test_group_func(group_op, global_size, local_size, dtype):
 
 
 def _from_host(arr, buffer):
-    ret = dpt.usm_ndarray(arr.shape, dtype=arr.dtype, buffer=buffer)
+    device = get_default_device_name()
+    ret = dpt.usm_ndarray(arr.shape, dtype=arr.dtype, buffer=buffer).to_device(device)
     ret.usm_data.copy_from_host(arr.reshape((-1)).view("|u1"))
     return ret
 

--- a/numba_mlir/numba_mlir/python_runtime/lib/Boxing.cpp
+++ b/numba_mlir/numba_mlir/python_runtime/lib/Boxing.cpp
@@ -124,7 +124,7 @@ nmrtUnboxSyclInterface(PyObject *obj, arystruct_t *arystruct) {
       if (!elem || !PyLong_Check(elem.get()))
         return -1;
 
-      strides[i] = PyLong_AsLong(elem.get());
+      strides[i] = PyLong_AsLong(elem.get()) * itemsize;
     }
   }
 


### PR DESCRIPTION
* Properly map dpctl tensor layout
* Skip CFD GPU reduction tests too with opencl backend
* Make CFD tests respect `get_default_device_name()`
* Fix dpctl tensor strides unboxing
* Improve opencl backend `suggestGPUBlockSize` func
