### PR TITLE
Dont use non-uniform group funcs

### DIFF
--- a/mlir/include/numba/Dialect/gpu_runtime/IR/GpuRuntimeOps.td
+++ b/mlir/include/numba/Dialect/gpu_runtime/IR/GpuRuntimeOps.td
@@ -20,7 +20,9 @@ def GpuRuntime_Dialect : Dialect {
   let description = [{
       GpuRuntime Dialect for representing Gpu runtime ops for level zero runtime
     }];
-  let cppNamespace = "gpu_runtime";
+  let cppNamespace = "::gpu_runtime";
+
+  let hasCanonicalizer = 1;
   let hasConstantMaterializer = 1;
   let useDefaultAttributePrinterParser = 1;
   let useDefaultTypePrinterParser = 1;

--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -1471,7 +1471,6 @@ static mlir::spirv::TargetEnvAttr defaultCapsMapper(mlir::gpu::GPUModuleOp op) {
       spirv::Capability::Float16Buffer,
       spirv::Capability::Float64,
       spirv::Capability::GenericPointer,
-      spirv::Capability::GroupNonUniformArithmetic,
       spirv::Capability::Groups,
       spirv::Capability::Int16,
       spirv::Capability::Int64,

--- a/mlir/lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
+++ b/mlir/lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
@@ -58,10 +58,6 @@ static mlir::LogicalResult convertBlockingOp(gpu_runtime::GPUBarrierOp op,
   auto afterBlock = rewriter.splitBlock(ifBody, std::next(barrierIt));
   auto beforeBlock = rewriter.splitBlock(ifBody, ifBody->begin());
 
-  auto barrierLoc = op.getLoc();
-  auto barrierFlags = op.getFlags();
-  rewriter.eraseOp(op);
-
   rewriter.setInsertionPointToEnd(beforeBlock);
   rewriter.create<mlir::scf::YieldOp>(rewriter.getUnknownLoc(), yieldArgs);
 
@@ -92,7 +88,10 @@ static mlir::LogicalResult convertBlockingOp(gpu_runtime::GPUBarrierOp op,
 
   rewriter.mergeBlocks(beforeBlock, beforeIf.thenBlock());
 
+  auto barrierLoc = op.getLoc();
+  auto barrierFlags = op.getFlags();
   rewriter.create<gpu_runtime::GPUBarrierOp>(barrierLoc, barrierFlags);
+  rewriter.eraseOp(op);
 
   auto beforeIfResults = beforeIf.getResults();
 

--- a/mlir/lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
+++ b/mlir/lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
@@ -74,19 +74,9 @@ getNeutralValue(mlir::gpu::AllReduceOp reduceOp) {
 
 static mlir::LogicalResult convertBlockingOp(mlir::Operation *op,
                                              mlir::PatternRewriter &rewriter) {
-  auto launchOp = op->getParentOfType<mlir::gpu::LaunchOp>();
-
-  // Must be within launch op.
-  if (!launchOp)
-    return mlir::failure();
-
   // IfOp must be an immediate parent
   auto ifOp = mlir::dyn_cast<mlir::scf::IfOp>(op->getParentOp());
   if (!ifOp)
-    return mlir::failure();
-
-  // LaunchOp must be an immediate parent of ifOp.
-  if (ifOp->getParentOp() != launchOp)
     return mlir::failure();
 
   // IfOp with else block is not yet supported;

--- a/mlir/test/Transforms/make-barriers-uniform.mlir
+++ b/mlir/test/Transforms/make-barriers-uniform.mlir
@@ -9,7 +9,7 @@ func.func @test() {
     scf.if %cond {
       "test.test2"() : () -> ()
       %1 = "test.test3"() : () -> i32
-      gpu_runtime.barrier  1
+      gpu_runtime.barrier  1 {test.test_attr}
       "test.test4"() : () -> ()
       "test.test5"(%1) : (i32) -> ()
     }
@@ -29,7 +29,7 @@ func.func @test() {
 //       CHECK: %[[V2:.*]] = numba_util.undef : i32
 //       CHECK: scf.yield %[[V2]] : i32
 //       CHECK: }
-//       CHECK: gpu_runtime.barrier  1
+//       CHECK: gpu_runtime.barrier  1 {test.test_attr}
 //       CHECK: scf.if %[[COND]] {
 //       CHECK: "test.test4"() : () -> ()
 //       CHECK: "test.test5"(%[[RES1]]) : (i32) -> ()

--- a/mlir/test/Transforms/make-barriers-uniform.mlir
+++ b/mlir/test/Transforms/make-barriers-uniform.mlir
@@ -20,21 +20,21 @@ func.func @test() {
 
 // CHECK-LABEL: func @test
 //       CHECK: gpu.launch blocks
-//  CHECK-NEXT: %[[COND:.*]] = "test.test1"() : () -> i1
-//  CHECK-NEXT: %[[RES1:.*]] = scf.if %[[COND]] -> (i32) {
-//  CHECK-NEXT: "test.test2"() : () -> ()
-//  CHECK-NEXT: %[[V1:.*]] = "test.test3"() : () -> i32
-//  CHECK-NEXT: scf.yield %[[V1]] : i32
-//  CHECK-NEXT: } else {
-//  CHECK-NEXT: %[[V2:.*]] = numba_util.undef : i32
-//  CHECK-NEXT: scf.yield %[[V2]] : i32
-//  CHECK-NEXT: }
-//  CHECK-NEXT: gpu_runtime.barrier  1
-//  CHECK-NEXT: scf.if %[[COND]] {
-//  CHECK-NEXT: "test.test4"() : () -> ()
-//  CHECK-NEXT: "test.test5"(%[[RES1]]) : (i32) -> ()
-//  CHECK-NEXT: }
-//  CHECK-NEXT: gpu.terminator
+//       CHECK: %[[COND:.*]] = "test.test1"() : () -> i1
+//       CHECK: %[[RES1:.*]] = scf.if %[[COND]] -> (i32) {
+//       CHECK: "test.test2"() : () -> ()
+//       CHECK: %[[V1:.*]] = "test.test3"() : () -> i32
+//       CHECK: scf.yield %[[V1]] : i32
+//       CHECK: } else {
+//       CHECK: %[[V2:.*]] = numba_util.undef : i32
+//       CHECK: scf.yield %[[V2]] : i32
+//       CHECK: }
+//       CHECK: gpu_runtime.barrier  1
+//       CHECK: scf.if %[[COND]] {
+//       CHECK: "test.test4"() : () -> ()
+//       CHECK: "test.test5"(%[[RES1]]) : (i32) -> ()
+//       CHECK: }
+//       CHECK: gpu.terminator
 //       CHECK: return
 
 // -----
@@ -65,34 +65,34 @@ func.func @test() {
 
 // CHECK-LABEL: func @test
 //       CHECK: gpu.launch blocks
-//  CHECK-NEXT: %[[COND:.*]] = "test.test1"() : () -> i1
-//  CHECK-NEXT: %[[RES1:.*]]:2 = scf.if %[[COND]] -> (i32, i64) {
-//  CHECK-NEXT: "test.test2"() : () -> ()
-//  CHECK-NEXT: %[[V1:.*]] = "test.test3"() : () -> i32
-//  CHECK-NEXT: %[[V2:.*]] = "test.test4"() : () -> i64
-//  CHECK-NEXT: scf.yield %[[V1]], %[[V2]] : i32, i64
-//  CHECK-NEXT: } else {
-//  CHECK-NEXT: %[[V3:.*]] = numba_util.undef : i32
-//  CHECK-NEXT: %[[V4:.*]] = numba_util.undef : i64
-//  CHECK-NEXT: scf.yield %[[V3]], %[[V4]] : i32, i64
-//  CHECK-NEXT: }
-//  CHECK-NEXT: gpu_runtime.barrier  1
-//  CHECK-NEXT: %[[RES2:.*]] = scf.if %[[COND]] -> (index) {
-//  CHECK-NEXT: "test.test5"() : () -> ()
-//  CHECK-NEXT: "test.test6"(%[[RES1]]#0) : (i32) -> ()
-//  CHECK-NEXT: %[[V5:.*]] = "test.test7"() : () -> index
-//  CHECK-NEXT: scf.yield %[[V5]] : index
-//  CHECK-NEXT: } else {
-//  CHECK-NEXT: %[[V6:.*]] = numba_util.undef : index
-//  CHECK-NEXT: scf.yield %[[V6]] : index
-//  CHECK-NEXT: }
-//  CHECK-NEXT: gpu_runtime.barrier 2
-//  CHECK-NEXT: scf.if %[[COND]] {
-//  CHECK-NEXT: "test.test8"() : () -> ()
-//  CHECK-NEXT: "test.test9"(%[[RES1]]#1) : (i64) -> ()
-//  CHECK-NEXT: "test.test10"(%[[RES2]]) : (index) -> ()
-//  CHECK-NEXT: }
-//  CHECK-NEXT: gpu.terminator
+//       CHECK: %[[COND:.*]] = "test.test1"() : () -> i1
+//       CHECK: %[[RES1:.*]]:2 = scf.if %[[COND]] -> (i32, i64) {
+//       CHECK: "test.test2"() : () -> ()
+//       CHECK: %[[V1:.*]] = "test.test3"() : () -> i32
+//       CHECK: %[[V2:.*]] = "test.test4"() : () -> i64
+//       CHECK: scf.yield %[[V1]], %[[V2]] : i32, i64
+//       CHECK: } else {
+//       CHECK: %[[V3:.*]] = numba_util.undef : i32
+//       CHECK: %[[V4:.*]] = numba_util.undef : i64
+//       CHECK: scf.yield %[[V3]], %[[V4]] : i32, i64
+//       CHECK: }
+//       CHECK: gpu_runtime.barrier  1
+//       CHECK: %[[RES2:.*]] = scf.if %[[COND]] -> (index) {
+//       CHECK: "test.test5"() : () -> ()
+//       CHECK: "test.test6"(%[[RES1]]#0) : (i32) -> ()
+//       CHECK: %[[V5:.*]] = "test.test7"() : () -> index
+//       CHECK: scf.yield %[[V5]] : index
+//       CHECK: } else {
+//       CHECK: %[[V6:.*]] = numba_util.undef : index
+//       CHECK: scf.yield %[[V6]] : index
+//       CHECK: }
+//       CHECK: gpu_runtime.barrier 2
+//       CHECK: scf.if %[[COND]] {
+//       CHECK: "test.test8"() : () -> ()
+//       CHECK: "test.test9"(%[[RES1]]#1) : (i64) -> ()
+//       CHECK: "test.test10"(%[[RES2]]) : (index) -> ()
+//       CHECK: }
+//       CHECK: gpu.terminator
 //       CHECK: return
 
 // -----
@@ -124,29 +124,29 @@ func.func @test() {
 // CHECK-LABEL: func @test
 //       CHECK: %[[NEUTRAL:.*]] = arith.constant 0 : i64
 //       CHECK: gpu.launch blocks
-//  CHECK-NEXT: %[[COND:.*]] = "test.test1"() : () -> i1
-//  CHECK-NEXT: %[[RES1:.*]]:2 = scf.if %[[COND]] -> (i32, i64) {
-//  CHECK-NEXT: "test.test2"() : () -> ()
-//  CHECK-NEXT: %[[V1:.*]] = "test.test3"() : () -> i32
-//  CHECK-NEXT: %[[V2:.*]] = "test.test4"() : () -> i64
-//  CHECK-NEXT: scf.yield %[[V1]], %[[V2]] : i32, i64
-//  CHECK-NEXT: } else {
-//  CHECK-NEXT: %[[V3:.*]] = numba_util.undef : i32
-//  CHECK-NEXT: %[[V4:.*]] = numba_util.undef : i64
-//  CHECK-NEXT: scf.yield %[[V3]], %[[V4]] : i32, i64
-//  CHECK-NEXT: }
-//  CHECK-NEXT: %[[RARG:.*]] = arith.select %[[COND]], %[[RES1]]#1, %[[NEUTRAL]] : i64
-//  CHECK-NEXT: %[[RRES:.*]] = gpu.all_reduce %[[RARG]] uniform {
-//  CHECK-NEXT:  ^bb0(%[[A1:.*]]: i64, %[[A2:.*]]: i64):
-//  CHECK-NEXT:   %[[X:.*]] = arith.xori %[[A1]], %[[A2]] : i64
-//  CHECK-NEXT:   "gpu.yield"(%[[X]]) : (i64) -> ()
-//  CHECK-NEXT:   } : (i64) -> i64
-//  CHECK-NEXT: scf.if %[[COND]] {
-//  CHECK-NEXT: "test.test5"() : () -> ()
-//  CHECK-NEXT: "test.test6"(%[[RES1]]#0) : (i32) -> ()
-//  CHECK-NEXT: "test.test7"(%[[RRES]]) : (i64) -> ()
-//  CHECK-NEXT: }
-//  CHECK-NEXT: gpu.terminator
+//       CHECK: %[[COND:.*]] = "test.test1"() : () -> i1
+//       CHECK: %[[RES1:.*]]:2 = scf.if %[[COND]] -> (i32, i64) {
+//       CHECK: "test.test2"() : () -> ()
+//       CHECK: %[[V1:.*]] = "test.test3"() : () -> i32
+//       CHECK: %[[V2:.*]] = "test.test4"() : () -> i64
+//       CHECK: scf.yield %[[V1]], %[[V2]] : i32, i64
+//       CHECK: } else {
+//       CHECK: %[[V3:.*]] = numba_util.undef : i32
+//       CHECK: %[[V4:.*]] = numba_util.undef : i64
+//       CHECK: scf.yield %[[V3]], %[[V4]] : i32, i64
+//       CHECK: }
+//       CHECK: %[[RARG:.*]] = arith.select %[[COND]], %[[RES1]]#1, %[[NEUTRAL]] : i64
+//       CHECK: %[[RRES:.*]] = gpu.all_reduce %[[RARG]] uniform {
+//       CHECK:  ^bb0(%[[A1:.*]]: i64, %[[A2:.*]]: i64):
+//       CHECK:   %[[X:.*]] = arith.xori %[[A1]], %[[A2]] : i64
+//       CHECK:   "gpu.yield"(%[[X]]) : (i64) -> ()
+//       CHECK:   } : (i64) -> i64
+//       CHECK: scf.if %[[COND]] {
+//       CHECK: "test.test5"() : () -> ()
+//       CHECK: "test.test6"(%[[RES1]]#0) : (i32) -> ()
+//       CHECK: "test.test7"(%[[RRES]]) : (i64) -> ()
+//       CHECK: }
+//       CHECK: gpu.terminator
 //       CHECK: return
 
 // -----
@@ -174,24 +174,24 @@ func.func @test() {
 // CHECK-LABEL: func @test
 //       CHECK: %[[NEUTRAL:.*]] = arith.constant 1 : i64
 //       CHECK: gpu.launch blocks
-//  CHECK-NEXT: %[[COND:.*]] = "test.test1"() : () -> i1
-//  CHECK-NEXT: %[[RES1:.*]]:2 = scf.if %[[COND]] -> (i32, i64) {
-//  CHECK-NEXT: "test.test2"() : () -> ()
-//  CHECK-NEXT: %[[V1:.*]] = "test.test3"() : () -> i32
-//  CHECK-NEXT: %[[V2:.*]] = "test.test4"() : () -> i64
-//  CHECK-NEXT: scf.yield %[[V1]], %[[V2]] : i32, i64
-//  CHECK-NEXT: } else {
-//  CHECK-NEXT: %[[V3:.*]] = numba_util.undef : i32
-//  CHECK-NEXT: %[[V4:.*]] = numba_util.undef : i64
-//  CHECK-NEXT: scf.yield %[[V3]], %[[V4]] : i32, i64
-//  CHECK-NEXT: }
-//  CHECK-NEXT: %[[RARG:.*]] = arith.select %[[COND]], %[[RES1]]#1, %[[NEUTRAL]] : i64
-//  CHECK-NEXT: %[[RRES:.*]] = gpu.all_reduce mul %[[RARG]] {
-//  CHECK-NEXT:   } : (i64) -> i64
-//  CHECK-NEXT: scf.if %[[COND]] {
-//  CHECK-NEXT: "test.test5"() : () -> ()
-//  CHECK-NEXT: "test.test6"(%[[RES1]]#0) : (i32) -> ()
-//  CHECK-NEXT: "test.test7"(%[[RRES]]) : (i64) -> ()
-//  CHECK-NEXT: }
-//  CHECK-NEXT: gpu.terminator
+//       CHECK: %[[COND:.*]] = "test.test1"() : () -> i1
+//       CHECK: %[[RES1:.*]]:2 = scf.if %[[COND]] -> (i32, i64) {
+//       CHECK: "test.test2"() : () -> ()
+//       CHECK: %[[V1:.*]] = "test.test3"() : () -> i32
+//       CHECK: %[[V2:.*]] = "test.test4"() : () -> i64
+//       CHECK: scf.yield %[[V1]], %[[V2]] : i32, i64
+//       CHECK: } else {
+//       CHECK: %[[V3:.*]] = numba_util.undef : i32
+//       CHECK: %[[V4:.*]] = numba_util.undef : i64
+//       CHECK: scf.yield %[[V3]], %[[V4]] : i32, i64
+//       CHECK: }
+//       CHECK: %[[RARG:.*]] = arith.select %[[COND]], %[[RES1]]#1, %[[NEUTRAL]] : i64
+//       CHECK: %[[RRES:.*]] = gpu.all_reduce mul %[[RARG]] {
+//       CHECK:   } : (i64) -> i64
+//       CHECK: scf.if %[[COND]] {
+//       CHECK: "test.test5"() : () -> ()
+//       CHECK: "test.test6"(%[[RES1]]#0) : (i32) -> ()
+//       CHECK: "test.test7"(%[[RRES]]) : (i64) -> ()
+//       CHECK: }
+//       CHECK: gpu.terminator
 //       CHECK: return

--- a/mlir/test/Transforms/make-barriers-uniform.mlir
+++ b/mlir/test/Transforms/make-barriers-uniform.mlir
@@ -35,7 +35,7 @@ func.func @test() {
 //  CHECK-NEXT: "test.test5"(%[[RES1]]) : (i32) -> ()
 //  CHECK-NEXT: }
 //  CHECK-NEXT: gpu.terminator
-//        CHECK: return
+//       CHECK: return
 
 // -----
 
@@ -140,11 +140,58 @@ func.func @test() {
 //  CHECK-NEXT:  ^bb0(%[[A1:.*]]: i64, %[[A2:.*]]: i64):
 //  CHECK-NEXT:   %[[X:.*]] = arith.xori %[[A1]], %[[A2]] : i64
 //  CHECK-NEXT:   "gpu.yield"(%[[X]]) : (i64) -> ()
-//  CHECK-NEXT:   } : (
+//  CHECK-NEXT:   } : (i64) -> i64
 //  CHECK-NEXT: scf.if %[[COND]] {
 //  CHECK-NEXT: "test.test5"() : () -> ()
 //  CHECK-NEXT: "test.test6"(%[[RES1]]#0) : (i32) -> ()
 //  CHECK-NEXT: "test.test7"(%[[RRES]]) : (i64) -> ()
 //  CHECK-NEXT: }
 //  CHECK-NEXT: gpu.terminator
-//        CHECK: return
+//       CHECK: return
+
+// -----
+
+func.func @test() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  gpu.launch blocks(%bx, %by, %bz) in (%grid_x = %c1, %grid_y = %c1, %grid_z = %c1)
+             threads(%tx, %ty, %tz) in (%block_x = %c1, %block_y = %c1, %block_z = %c1) {
+    %cond = "test.test1"() : () -> i1
+    scf.if %cond {
+      "test.test2"() : () -> ()
+      %1 = "test.test3"() : () -> i32
+      %2 = "test.test4"() : () -> i64
+      %3 = gpu.all_reduce mul %2 {} : (i64) -> (i64)
+      "test.test5"() : () -> ()
+      "test.test6"(%1) : (i32) -> ()
+      "test.test7"(%3) : (i64) -> ()
+    }
+    gpu.terminator
+  }
+  return
+}
+
+// CHECK-LABEL: func @test
+//       CHECK: %[[NEUTRAL:.*]] = arith.constant 1 : i64
+//       CHECK: gpu.launch blocks
+//  CHECK-NEXT: %[[COND:.*]] = "test.test1"() : () -> i1
+//  CHECK-NEXT: %[[RES1:.*]]:2 = scf.if %[[COND]] -> (i32, i64) {
+//  CHECK-NEXT: "test.test2"() : () -> ()
+//  CHECK-NEXT: %[[V1:.*]] = "test.test3"() : () -> i32
+//  CHECK-NEXT: %[[V2:.*]] = "test.test4"() : () -> i64
+//  CHECK-NEXT: scf.yield %[[V1]], %[[V2]] : i32, i64
+//  CHECK-NEXT: } else {
+//  CHECK-NEXT: %[[V3:.*]] = numba_util.undef : i32
+//  CHECK-NEXT: %[[V4:.*]] = numba_util.undef : i64
+//  CHECK-NEXT: scf.yield %[[V3]], %[[V4]] : i32, i64
+//  CHECK-NEXT: }
+//  CHECK-NEXT: %[[RARG:.*]] = arith.select %[[COND]], %[[RES1]]#1, %[[NEUTRAL]] : i64
+//  CHECK-NEXT: %[[RRES:.*]] = gpu.all_reduce mul %[[RARG]] {
+//  CHECK-NEXT:   } : (i64) -> i64
+//  CHECK-NEXT: scf.if %[[COND]] {
+//  CHECK-NEXT: "test.test5"() : () -> ()
+//  CHECK-NEXT: "test.test6"(%[[RES1]]#0) : (i32) -> ()
+//  CHECK-NEXT: "test.test7"(%[[RRES]]) : (i64) -> ()
+//  CHECK-NEXT: }
+//  CHECK-NEXT: gpu.terminator
+//       CHECK: return

--- a/mlir/test/Transforms/set-spirv-capability.mlir
+++ b/mlir/test/Transforms/set-spirv-capability.mlir
@@ -3,7 +3,7 @@
 module attributes {gpu.container_module} {
 
 // CHECK: module attributes {gpu.container_module} {
-// CHECK: gpu.module @main_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Linkage, Kernel, Vector16, Float16Buffer, Float16, Float64, Int64, Groups, Int16, GenericPointer, Int8, GroupNonUniformArithmetic, ExpectAssumeKHR, AtomicFloat32AddEXT], [SPV_KHR_expect_assume, SPV_EXT_shader_atomic_float_add]>, api=OpenCL, #spirv.resource_limits<>>} {
+// CHECK: gpu.module @main_kernel attributes {spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Addresses, Linkage, Kernel, Vector16, Float16Buffer, Float16, Float64, Int64, Groups, Int16, GenericPointer, Int8, ExpectAssumeKHR, AtomicFloat32AddEXT], [SPV_KHR_expect_assume, SPV_EXT_shader_atomic_float_add]>, api=OpenCL, #spirv.resource_limits<>>} {
 
   gpu.module @main_kernel {
     gpu.func @main_kernel(%arg0: memref<8xf32>, %arg1: memref<8xf32>, %arg2: memref<8xf32>) kernel attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {

--- a/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
@@ -47,14 +47,6 @@ def require_dpctl(func):
 
 _def_device = get_default_device_name()
 
-
-def skip_opencl_reductions(func):
-    global _def_device
-    return pytest.mark.skipif(
-        _def_device.startswith("opencl"), reason="Reduction issue witch OpenCL backend"
-    )(func)
-
-
 _test_values = [
     True,
     False,
@@ -905,7 +897,6 @@ def test_private_memory(blocksize):
 
 
 @require_gpu
-@skip_opencl_reductions
 @pytest.mark.parametrize("group_op", [group.reduce_add])
 @pytest.mark.parametrize("global_size", [1, 2, 4, 27, 67, 101])
 @pytest.mark.parametrize("local_size", [1, 2, 7, 17, 33])
@@ -1179,7 +1170,6 @@ def test_cfd_reshape():
 
 @pytest.mark.smoke
 @require_dpctl
-@skip_opencl_reductions
 @pytest.mark.parametrize("size", [1, 7, 16, 64, 65, 256, 512, 1024 * 1024])
 def test_cfd_reduce1(size):
     if size == 1:
@@ -1210,7 +1200,6 @@ _shapes = (1, 7, 16, 25, 64, 65)
 
 
 @require_dpctl
-@skip_opencl_reductions
 @parametrize_function_variants(
     "py_func",
     [

--- a/numba_mlir_gpu_runtime_sycl/lib/GpuRuntime.cpp
+++ b/numba_mlir_gpu_runtime_sycl/lib/GpuRuntime.cpp
@@ -407,7 +407,7 @@ gpuxGetDeviceCapabilities(numba::OffloadDeviceCapabilities *ret,
 
     // Spirv version is hardcoded for now.
     result.spirvMajorVersion = 1;
-    result.spirvMinorVersion = 3;
+    result.spirvMinorVersion = 2;
     result.hasFP16 = device.has(sycl::aspect::fp16);
     result.hasFP64 = device.has(sycl::aspect::fp64);
     *ret = result;


### PR DESCRIPTION
* Instead of relying on non-unifrom group funcs support (which sycl opencl backend doesn't have) extend `MakeBarriersUniformPass` to support gpu group reduce ops.
