### PR TITLE
Add user option to control gpu fp64 truncation behavior

### DIFF
--- a/mlir/include/numba/Dialect/gpu_runtime/IR/GpuRuntimeOps.hpp
+++ b/mlir/include/numba/Dialect/gpu_runtime/IR/GpuRuntimeOps.hpp
@@ -30,6 +30,7 @@
 namespace gpu_runtime {
 mlir::StringRef getGpuAccessibleAttrName();
 mlir::StringRef getFenceFlagsAttrName();
+mlir::StringRef getFp64TruncateAttrName();
 
 enum class FenceFlags : int64_t {
   local = 1,

--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -2086,11 +2086,6 @@ struct TruncateF64ForGPUPass
 
   void runOnOperation() override {
     auto module = getOperation();
-    auto truncAttr = module->getAttrOfType<mlir::BoolAttr>(
-        gpu_runtime::getFp64TruncateAttrName());
-    if (truncAttr && !truncAttr.getValue())
-      return markAllAnalysesPreserved();
-
     auto *ctx = &getContext();
     mlir::ConversionTarget target(*ctx);
     mlir::TypeConverter converter;
@@ -2166,6 +2161,11 @@ struct TruncateF64ForGPUPass
     llvm::SmallVector<mlir::Value> newArgs;
     mlir::OpBuilder builder(ctx);
     for (auto gpuModule : module.getOps<mlir::gpu::GPUModuleOp>()) {
+      auto truncAttr = gpuModule->getAttrOfType<mlir::BoolAttr>(
+          gpu_runtime::getFp64TruncateAttrName());
+      if (truncAttr && !truncAttr.getValue())
+        continue;
+
       auto targetEnv = mlir::spirv::lookupTargetEnv(gpuModule);
       if (!targetEnv) {
         gpuModule->emitError("TargetEnv not found");

--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -2086,6 +2086,7 @@ struct TruncateF64ForGPUPass
 
   void runOnOperation() override {
     auto module = getOperation();
+
     auto *ctx = &getContext();
     mlir::ConversionTarget target(*ctx);
     mlir::TypeConverter converter;

--- a/mlir/lib/Dialect/gpu_runtime/IR/GpuRuntimeOps.cpp
+++ b/mlir/lib/Dialect/gpu_runtime/IR/GpuRuntimeOps.cpp
@@ -257,6 +257,9 @@ mlir::StringRef getGpuAccessibleAttrName() {
 }
 
 mlir::StringRef getFenceFlagsAttrName() { return "gpu_runtime.fence_flags"; }
+mlir::StringRef getFp64TruncateAttrName() {
+  return "gpu_runtime.fp64_truncate";
+}
 } // namespace gpu_runtime
 
 // TODO: unify with upstream

--- a/numba_mlir/numba_mlir/decorators.py
+++ b/numba_mlir/numba_mlir/decorators.py
@@ -32,6 +32,14 @@ def mlir_jit(
             **options
         )
 
+    fp64_truncate = options.get("gpu_fp64_truncate", False)
+    assert fp64_truncate in [
+        True,
+        False,
+        "auto",
+    ], 'gpu_fp64_truncate supported values are True/False/"auto"'
+    options.pop("gpu_fp64_truncate", None)
+
     pipeline = (
         mlir_compiler_gpu_pipeline
         if options.get("enable_gpu_pipeline", True)

--- a/numba_mlir/numba_mlir/decorators.py
+++ b/numba_mlir/numba_mlir/decorators.py
@@ -6,7 +6,7 @@
 Define @jit and related decorators.
 """
 
-from .mlir.compiler import mlir_compiler_pipeline, mlir_compiler_gpu_pipeline
+from .mlir.compiler import mlir_compiler_pipeline, get_gpu_pipeline
 from .mlir.vectorize import vectorize as mlir_vectorize
 from .mlir.settings import USE_MLIR
 
@@ -41,7 +41,7 @@ def mlir_jit(
     options.pop("gpu_fp64_truncate", None)
 
     pipeline = (
-        mlir_compiler_gpu_pipeline
+        get_gpu_pipeline(fp64_truncate)
         if options.get("enable_gpu_pipeline", True)
         else mlir_compiler_pipeline
     )

--- a/numba_mlir/numba_mlir/mlir/compiler.py
+++ b/numba_mlir/numba_mlir/mlir/compiler.py
@@ -100,6 +100,7 @@ class mlir_compiler_pipeline(orig_CompilerBase):
             pms.append(mlir_PassBuilder.define_objectmode_pipeline(self.state))
         return pms
 
+
 @functools.cache
 def get_gpu_pipeline(fp64_truncate):
     class mlir_compiler_gpu_pipeline(orig_CompilerBase):
@@ -109,7 +110,9 @@ def get_gpu_pipeline(fp64_truncate):
             if not self.state.flags.force_pyobject:
                 pms.append(
                     mlir_PassBuilder.define_nopython_pipeline(
-                        self.state, enable_gpu_pipeline=True, fp64_truncate=fp64_truncate
+                        self.state,
+                        enable_gpu_pipeline=True,
+                        fp64_truncate=fp64_truncate,
                     )
                 )
             if self.state.status.can_fallback or self.state.flags.force_pyobject:

--- a/numba_mlir/numba_mlir/mlir/kernel_impl.py
+++ b/numba_mlir/numba_mlir/mlir/kernel_impl.py
@@ -107,7 +107,9 @@ class Kernel(KernelBase):
     def __init__(self, func, kwargs):
         super().__init__(func)
         fp64_truncate = kwargs.get("gpu_fp64_truncate", False)
-        self._jit_func = mlir_njit(inline="always", enable_gpu_pipeline=True, gpu_fp64_truncate=fp64_truncate)(func)
+        self._jit_func = mlir_njit(
+            inline="always", enable_gpu_pipeline=True, gpu_fp64_truncate=fp64_truncate
+        )(func)
         self._kern_body = mlir_njit(enable_gpu_pipeline=True, **kwargs)(_kernel_body)
         self._kern_body_def_size = mlir_njit(enable_gpu_pipeline=True, **kwargs)(
             _kernel_body_def_size

--- a/numba_mlir/numba_mlir/mlir/kernel_impl.py
+++ b/numba_mlir/numba_mlir/mlir/kernel_impl.py
@@ -106,7 +106,8 @@ def _extend_dims(dims):
 class Kernel(KernelBase):
     def __init__(self, func, kwargs):
         super().__init__(func)
-        self._jit_func = mlir_njit(inline="always", enable_gpu_pipeline=True)(func)
+        fp64_truncate = kwargs.get("gpu_fp64_truncate", False)
+        self._jit_func = mlir_njit(inline="always", enable_gpu_pipeline=True, gpu_fp64_truncate=fp64_truncate)(func)
         self._kern_body = mlir_njit(enable_gpu_pipeline=True, **kwargs)(_kernel_body)
         self._kern_body_def_size = mlir_njit(enable_gpu_pipeline=True, **kwargs)(
             _kernel_body_def_size

--- a/numba_mlir/numba_mlir/mlir/passes.py
+++ b/numba_mlir/numba_mlir/mlir/passes.py
@@ -205,8 +205,6 @@ class MlirBackend(MlirBackendBase):
         return True
 
 
-
-
 @functools.cache
 def get_gpu_backend(fp64_trunc):
     class MlirBackendGPU(MlirBackend):

--- a/numba_mlir/numba_mlir/mlir/passes.py
+++ b/numba_mlir/numba_mlir/mlir/passes.py
@@ -66,6 +66,7 @@ class MlirBackendBase(FunctionPass):
     def __init__(self, push_func_stack):
         self._push_func_stack = push_func_stack
         self._get_func_name = func_registry.get_func_name
+        self._fp64_truncate = False
         FunctionPass.__init__(self)
 
     def run_pass(self, state):
@@ -141,6 +142,7 @@ class MlirBackendBase(FunctionPass):
         )
         ctx["opt_level"] = lambda: OPT_LEVEL
         ctx["globals"] = lambda: state.func_id.func.__globals__
+        ctx["fp64_truncate"] = lambda: self._fp64_truncate
         return ctx
 
 

--- a/numba_mlir/numba_mlir/mlir/passes.py
+++ b/numba_mlir/numba_mlir/mlir/passes.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import functools
+
 from numba.core import types
 from numba.core.compiler import DEFAULT_FLAGS, compile_result
 from numba.core.compiler_machinery import FunctionPass, register_pass
@@ -203,11 +205,17 @@ class MlirBackend(MlirBackendBase):
         return True
 
 
-@register_pass(mutates_CFG=True, analysis_only=False)
-class MlirBackendGPU(MlirBackend):
-    def __init__(self):
-        MlirBackend.__init__(self)
-        self.enable_gpu_pipeline = True
+
+
+@functools.cache
+def get_gpu_backend(fp64_trunc):
+    class MlirBackendGPU(MlirBackend):
+        def __init__(self):
+            MlirBackend.__init__(self)
+            self.enable_gpu_pipeline = True
+            self._fp64_truncate = fp64_trunc
+
+    return register_pass(mutates_CFG=True, analysis_only=False)(MlirBackendGPU)
 
 
 @register_pass(mutates_CFG=True, analysis_only=False)

--- a/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
@@ -22,7 +22,22 @@ from numba_mlir.mlir.passes import (
 from .utils import JitfuncCache, parametrize_function_variants
 from .utils import njit_cached as njit
 
-kernel_cache = JitfuncCache(kernel)
+FP64_TRUNCATE = readenv("NUMBA_MLIR_TESTS_FP64_TRUNCATE", str, "")
+
+
+def kernel_wrapper(*args, **kwargs):
+    if FP64_TRUNCATE:
+        if FP64_TRUNCATE == "auto":
+            fp64_truncate = "auto"
+        else:
+            fp64_truncate = bool(FP64_TRUNCATE)
+
+        kwargs["gpu_fp64_truncate"] = fp64_truncate
+
+    return kernel(*args, **kwargs)
+
+
+kernel_cache = JitfuncCache(kernel_wrapper)
 kernel_cached = kernel_cache.cached_decorator
 
 GPU_TESTS_ENABLED = readenv("NUMBA_MLIR_ENABLE_GPU_TESTS", int, 0)

--- a/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
@@ -20,7 +20,7 @@ from numba_mlir.mlir.passes import (
 )
 
 from .utils import JitfuncCache, parametrize_function_variants
-from .utils import njit_cached as njit
+from numba_mlir import njit as njit_orig
 
 FP64_TRUNCATE = readenv("NUMBA_MLIR_TESTS_FP64_TRUNCATE", str, "")
 
@@ -39,6 +39,22 @@ def kernel_wrapper(*args, **kwargs):
 
 kernel_cache = JitfuncCache(kernel_wrapper)
 kernel_cached = kernel_cache.cached_decorator
+
+
+def njit_wrapper(*args, **kwargs):
+    if FP64_TRUNCATE:
+        if FP64_TRUNCATE == "auto":
+            fp64_truncate = "auto"
+        else:
+            fp64_truncate = bool(FP64_TRUNCATE)
+
+        kwargs["gpu_fp64_truncate"] = fp64_truncate
+
+    return njit_orig(*args, **kwargs)
+
+
+njit_cache = JitfuncCache(njit_wrapper)
+njit = njit_cache.cached_decorator
 
 GPU_TESTS_ENABLED = readenv("NUMBA_MLIR_ENABLE_GPU_TESTS", int, 0)
 DPCTL_TESTS_ENABLED = readenv("NUMBA_MLIR_ENABLE_DPCTL_TESTS", int, 0)

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -222,6 +222,15 @@ private:
       func->setAttr(numba::util::attributes::getMaxConcurrencyName(),
                     builder.getI64IntegerAttr(maxConcurrency));
 
+    auto fp64_truncate = compilationContext["fp64_truncate"]();
+    if (fp64_truncate.equal(py::str("auto"))) {
+      // Nothing
+    } else {
+      auto attr =
+          mlir::BoolAttr::get(mod->getContext(), fp64_truncate.cast<bool>());
+      mod->setAttr(gpu_runtime::getFp64TruncateAttrName(), attr);
+    }
+
     globals = compilationContext["globals"]();
 
     mod.push_back(func);

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -228,7 +228,7 @@ private:
     } else {
       auto attr =
           mlir::BoolAttr::get(mod->getContext(), fp64_truncate.cast<bool>());
-      mod->setAttr(gpu_runtime::getFp64TruncateAttrName(), attr);
+      func->setAttr(gpu_runtime::getFp64TruncateAttrName(), attr);
     }
 
     globals = compilationContext["globals"]();

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -1712,7 +1712,8 @@ public:
       return signalPassFailure();
     }
 
-    auto use = mlir::dyn_cast<mlir::gpu::LaunchFuncOp>(funcUses->begin()->getUser());
+    auto use =
+        mlir::dyn_cast<mlir::gpu::LaunchFuncOp>(funcUses->begin()->getUser());
     if (!use) {
       gpuMod->emitError("Invalid func use");
       return signalPassFailure();
@@ -1724,7 +1725,8 @@ public:
       return signalPassFailure();
     }
 
-    auto attrName = mlir::StringAttr::get(&getContext(), gpu_runtime::getFp64TruncateAttrName());
+    auto attrName = mlir::StringAttr::get(
+        &getContext(), gpu_runtime::getFp64TruncateAttrName());
     auto attr = parent->getAttr(attrName);
     if (attr)
       gpuMod->setAttr(attrName, attr);
@@ -1991,7 +1993,8 @@ static void populateLowerToGPUPipelineMed(mlir::OpPassManager &pm) {
   funcPM.addPass(std::make_unique<SinkGpuDimsPass>());
   funcPM.addPass(std::make_unique<GpuLaunchSinkOpsPass>());
   pm.addPass(mlir::createGpuKernelOutliningPass());
-  pm.addNestedPass<mlir::gpu::GPUModuleOp>(std::make_unique<GpuPropagateFp64truncFlagPass>());
+  pm.addNestedPass<mlir::gpu::GPUModuleOp>(
+      std::make_unique<GpuPropagateFp64truncFlagPass>());
   pm.addPass(std::make_unique<NameGpuModulesPass>());
   pm.addPass(mlir::createSymbolDCEPass());
 

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -1679,6 +1679,58 @@ public:
   }
 };
 
+class GpuPropagateFp64truncFlagPass
+    : public mlir::PassWrapper<GpuPropagateFp64truncFlagPass,
+                               mlir::OperationPass<mlir::gpu::GPUModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(GpuPropagateFp64truncFlagPass)
+
+  virtual void
+  getDependentDialects(mlir::DialectRegistry &registry) const override {
+    registry.insert<mlir::gpu::GPUDialect>();
+  }
+
+  void runOnOperation() override {
+    auto gpuMod = getOperation();
+    auto mod = gpuMod->getParentOfType<mlir::ModuleOp>();
+    if (!mod) {
+      gpuMod->emitError("No module parent");
+      return signalPassFailure();
+    }
+
+    auto funcs = gpuMod.getOps<mlir::gpu::GPUFuncOp>();
+    if (!llvm::hasSingleElement(funcs)) {
+      gpuMod->emitError("GPU module must have exactly one func");
+      return signalPassFailure();
+    }
+
+    auto gpuFunc = *funcs.begin();
+
+    auto funcUses = mlir::SymbolTable::getSymbolUses(gpuFunc, mod);
+    if (!funcUses || !llvm::hasSingleElement(*funcUses)) {
+      gpuMod->emitError("GPU func must have exactly one use");
+      return signalPassFailure();
+    }
+
+    auto use = mlir::dyn_cast<mlir::gpu::LaunchFuncOp>(funcUses->begin()->getUser());
+    if (!use) {
+      gpuMod->emitError("Invalid func use");
+      return signalPassFailure();
+    }
+
+    auto parent = use->getParentOfType<mlir::FunctionOpInterface>();
+    if (!parent) {
+      gpuMod->emitError("Invalid func parent");
+      return signalPassFailure();
+    }
+
+    auto attrName = mlir::StringAttr::get(&getContext(), gpu_runtime::getFp64TruncateAttrName());
+    auto attr = parent->getAttr(attrName);
+    if (attr)
+      gpuMod->setAttr(attrName, attr);
+  }
+};
+
 static const constexpr llvm::StringLiteral
     kGpuModuleDeviceName("gpu_module_device");
 
@@ -1939,6 +1991,7 @@ static void populateLowerToGPUPipelineMed(mlir::OpPassManager &pm) {
   funcPM.addPass(std::make_unique<SinkGpuDimsPass>());
   funcPM.addPass(std::make_unique<GpuLaunchSinkOpsPass>());
   pm.addPass(mlir::createGpuKernelOutliningPass());
+  pm.addNestedPass<mlir::gpu::GPUModuleOp>(std::make_unique<GpuPropagateFp64truncFlagPass>());
   pm.addPass(std::make_unique<NameGpuModulesPass>());
   pm.addPass(mlir::createSymbolDCEPass());
 


### PR DESCRIPTION
* We have a pass which can truncate all fp64 computations in gpu funcs to fp32 if target hw doesn't support it.
* Previously this pass was "always on", which can lead to surprising behavior
* Add decorator flag `gpu_fp64_truncate`, possible values are `True`/`False`/`"auto"`, default is `False`

