### PR TITLE
plier types refactoring

### DIFF
--- a/mlir/include/numba/Dialect/plier/PlierOps.td
+++ b/mlir/include/numba/Dialect/plier/PlierOps.td
@@ -32,6 +32,8 @@ def Plier_SliceType : Plier_Type<"Slice", "slice", [], "::mlir::Type">;
 
 def Plier_BoundFunctionType : Plier_Type<"BoundFunction", "bound_function", [], "::mlir::Type">;
 
+def Plier_UndefinedType : Plier_Type<"Undefined", "undefined", [], "::mlir::Type">;
+
 def Plier_Py : Plier_Type<"Py", "pytype", [], "::mlir::Type"> {
 
   let parameters = (ins "::mlir::StringAttr":$name);
@@ -44,12 +46,6 @@ def Plier_Py : Plier_Type<"Py", "pytype", [], "::mlir::Type"> {
       return $_get(context, ::mlir::StringAttr::get(context, name));
     }]>
   ];
-
-  let extraClassDeclaration = [{
-    static PyType getUndefined(::mlir::MLIRContext *context) {
-      return PyType::get(context, "");
-    }
-  }];
 
   let assemblyFormat = "`<` $name `>`";
 }

--- a/mlir/include/numba/Dialect/plier/PlierOps.td
+++ b/mlir/include/numba/Dialect/plier/PlierOps.td
@@ -30,6 +30,8 @@ class Plier_Type<string name, string typeMnemonic, list<Trait> traits = [],
 
 def Plier_SliceType : Plier_Type<"Slice", "slice", [], "::mlir::Type">;
 
+def Plier_BoundFunctionType : Plier_Type<"BoundFunction", "bound_function", [], "::mlir::Type">;
+
 def Plier_Py : Plier_Type<"Py", "pytype", [], "::mlir::Type"> {
 
   let parameters = (ins "::mlir::StringAttr":$name);

--- a/mlir/lib/Dialect/plier/Dialect.cpp
+++ b/mlir/lib/Dialect/plier/Dialect.cpp
@@ -63,27 +63,25 @@ mlir::Operation *PlierDialect::materializeConstant(mlir::OpBuilder &builder,
 }
 
 void ConstOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
-
                     mlir::Attribute val) {
-  ConstOp::build(builder, state, PyType::getUndefined(state.getContext()), val);
+  ConstOp::build(builder, state, UndefinedType::get(state.getContext()), val);
 }
 
 void GlobalOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
                      mlir::StringRef name) {
-  GlobalOp::build(builder, state, PyType::getUndefined(state.getContext()),
-                  name);
+  GlobalOp::build(builder, state, UndefinedType::get(state.getContext()), name);
 }
 
 void BinOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
                   mlir::Value lhs, mlir::Value rhs, mlir::StringRef op) {
-  BinOp::build(builder, state, PyType::getUndefined(state.getContext()), lhs,
-               rhs, op);
+  BinOp::build(builder, state, UndefinedType::get(state.getContext()), lhs, rhs,
+               op);
 }
 
 void UnaryOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
                     mlir::Value value, mlir::StringRef op) {
-  UnaryOp::build(builder, state, PyType::getUndefined(state.getContext()),
-                 value, op);
+  UnaryOp::build(builder, state, UndefinedType::get(state.getContext()), value,
+                 op);
 }
 
 static mlir::Value propagateCasts(mlir::Value val, mlir::Type thisType);
@@ -123,7 +121,7 @@ mlir::OpFoldResult CastOp::fold(FoldAdaptor) {
   auto arg = getValue();
   auto opType = arg.getType();
   auto retType = getType();
-  if (opType == retType && opType != PyType::getUndefined(getContext()))
+  if (opType == retType && opType != UndefinedType::get(getContext()))
     return arg;
 
   if (auto res = propagateCasts(arg, retType))
@@ -166,7 +164,7 @@ void PyCallOp::build(
     llvm::StringRef func_name, mlir::ValueRange args, mlir::Value varargs,
     mlir::ArrayRef<std::pair<std::string, mlir::Value>> kwargs) {
   PyCallOp::build(builder, state,
-                  plier::PyType::getUndefined(builder.getContext()), func,
+                  plier::UndefinedType::get(builder.getContext()), func,
                   func_name, args, varargs, kwargs);
 }
 
@@ -191,55 +189,55 @@ void PyCallOp::build(
 
 void BuildTupleOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
                          ::mlir::ValueRange args) {
-  BuildTupleOp::build(builder, state, PyType::getUndefined(state.getContext()),
+  BuildTupleOp::build(builder, state, UndefinedType::get(state.getContext()),
                       args);
 }
 
 void GetItemOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
                       ::mlir::Value value, ::mlir::Value index) {
-  GetItemOp::build(builder, state, PyType::getUndefined(state.getContext()),
+  GetItemOp::build(builder, state, UndefinedType::get(state.getContext()),
                    value, index);
 }
 
 void GetiterOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
                       ::mlir::Value value) {
-  GetiterOp::build(builder, state, PyType::getUndefined(state.getContext()),
+  GetiterOp::build(builder, state, UndefinedType::get(state.getContext()),
                    value);
 }
 
 void IternextOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
                        ::mlir::Value value) {
-  IternextOp::build(builder, state, PyType::getUndefined(state.getContext()),
+  IternextOp::build(builder, state, UndefinedType::get(state.getContext()),
                     value);
 }
 
 void PairfirstOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
                         ::mlir::Value value) {
-  PairfirstOp::build(builder, state, PyType::getUndefined(state.getContext()),
+  PairfirstOp::build(builder, state, UndefinedType::get(state.getContext()),
                      value);
 }
 
 void PairsecondOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
                          ::mlir::Value value) {
-  PairsecondOp::build(builder, state, PyType::getUndefined(state.getContext()),
+  PairsecondOp::build(builder, state, UndefinedType::get(state.getContext()),
                       value);
 }
 
 void GetattrOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
                       mlir::Value value, mlir::StringRef name) {
-  GetattrOp::build(builder, state, PyType::getUndefined(state.getContext()),
+  GetattrOp::build(builder, state, UndefinedType::get(state.getContext()),
                    value, name);
 }
 
 void ExhaustIterOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
                           mlir::Value value, int64_t count) {
-  ExhaustIterOp::build(builder, state, PyType::getUndefined(state.getContext()),
+  ExhaustIterOp::build(builder, state, UndefinedType::get(state.getContext()),
                        value, builder.getI64IntegerAttr(count));
 }
 
 mlir::OpFoldResult ExhaustIterOp::fold(FoldAdaptor) {
   if (getType() == getOperand().getType() &&
-      getType() != plier::PyType::getUndefined(getContext())) {
+      getType() != plier::UndefinedType::get(getContext())) {
     return getOperand();
   }
   return nullptr;

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -964,11 +964,7 @@ struct BuildSliceToNtensor
 };
 
 static bool isBoundFunc(mlir::Type type) {
-  if (auto pyType = type.dyn_cast<plier::PyType>()) {
-    auto name = pyType.getName().getValue();
-    return name.consume_front("BoundFunction(") && name.consume_back(")");
-  }
-  return false;
+  return mlir::isa<plier::BoundFunctionType>(type);
 }
 
 struct NumpyCallsToNtensor : public mlir::OpConversionPattern<plier::PyCallOp> {

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToStdTypeConversion.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToStdTypeConversion.cpp
@@ -103,6 +103,7 @@ struct Conversion {
     dispatcherType = mod.attr("Dispatcher");
     functionType = mod.attr("Function");
     boundFunctionType = mod.attr("BoundFunction");
+    moduleType = mod.attr("Module");
     numberClassType = mod.attr("NumberClass");
     omittedType = mod.attr("Omitted");
   }
@@ -172,6 +173,9 @@ struct Conversion {
     if (py::isinstance(obj, boundFunctionType))
       return plier::BoundFunctionType::get(&context);
 
+    if (py::isinstance(obj, moduleType))
+      return numba::util::OpaqueType::get(&context);
+
     if (py::isinstance(obj, numberClassType)) {
       auto type = converter.convertType(context, obj.attr("instance_type"));
       if (!type)
@@ -234,6 +238,7 @@ private:
   py::object dispatcherType;
   py::object functionType;
   py::object boundFunctionType;
+  py::object moduleType;
   py::object numberClassType;
   py::object omittedType;
 };

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToStdTypeConversion.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToStdTypeConversion.cpp
@@ -102,6 +102,7 @@ struct Conversion {
     literalType = mod.attr("Literal");
     dispatcherType = mod.attr("Dispatcher");
     functionType = mod.attr("Function");
+    boundFunctionType = mod.attr("BoundFunction");
     numberClassType = mod.attr("NumberClass");
     omittedType = mod.attr("Omitted");
   }
@@ -168,6 +169,9 @@ struct Conversion {
     if (py::isinstance(obj, functionType))
       return mlir::FunctionType::get(&context, {}, {});
 
+    if (py::isinstance(obj, boundFunctionType))
+      return plier::BoundFunctionType::get(&context);
+
     if (py::isinstance(obj, numberClassType)) {
       auto type = converter.convertType(context, obj.attr("instance_type"));
       if (!type)
@@ -229,6 +233,7 @@ private:
   py::object literalType;
   py::object dispatcherType;
   py::object functionType;
+  py::object boundFunctionType;
   py::object numberClassType;
   py::object omittedType;
 };


### PR DESCRIPTION
Add dedicated types for `BoundFunction` and undefined type. Remove some unused code from `CallLowering`.