### PR TITLE
plier functions lowering refactoring

### DIFF
--- a/mlir/include/numba/Dialect/plier/PlierOps.td
+++ b/mlir/include/numba/Dialect/plier/PlierOps.td
@@ -30,6 +30,8 @@ class Plier_Type<string name, string typeMnemonic, list<Trait> traits = [],
 
 def Plier_SliceType : Plier_Type<"Slice", "slice", [], "::mlir::Type">;
 
+def Plier_FunctionType : Plier_Type<"Function", "function", [], "::mlir::Type">;
+
 def Plier_BoundFunctionType : Plier_Type<"BoundFunction", "bound_function", [], "::mlir::Type">;
 
 def Plier_UndefinedType : Plier_Type<"Undefined", "undefined", [], "::mlir::Type">;

--- a/mlir/lib/Transforms/CallLowering.cpp
+++ b/mlir/lib/Transforms/CallLowering.cpp
@@ -66,7 +66,7 @@ numba::CallOpLowering::matchAndRewrite(plier::PyCallOp op,
     return mlir::failure();
 
   auto func = op.getFunc();
-  if (!func || !mlir::isa<mlir::FunctionType>(func.getType()))
+  if (!func || !mlir::isa<plier::FunctionType>(func.getType()))
     return mlir::failure();
 
   auto funcName = op.getFuncName();

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -976,7 +976,7 @@ struct NumpyCallsToNtensor : public mlir::OpConversionPattern<plier::PyCallOp> {
   matchAndRewrite(plier::PyCallOp op, plier::PyCallOp::Adaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     auto func = adaptor.getFunc();
-    if (!func || !mlir::isa<mlir::FunctionType, plier::BoundFunctionType>(
+    if (!func || !mlir::isa<plier::FunctionType, plier::BoundFunctionType>(
                      func.getType()))
       return mlir::failure();
 

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToStdTypeConversion.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToStdTypeConversion.cpp
@@ -168,7 +168,7 @@ struct Conversion {
       return numba::util::OpaqueType::get(&context);
 
     if (py::isinstance(obj, functionType))
-      return mlir::FunctionType::get(&context, {}, {});
+      return plier::FunctionType::get(&context);
 
     if (py::isinstance(obj, boundFunctionType))
       return plier::BoundFunctionType::get(&context);


### PR DESCRIPTION
* Add dedicated `plier::Function` type
* Change array methods name handling in preparation for numba .57
