### PR TITLE
Some cleanups

### DIFF
--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -50,6 +50,7 @@
 #include "numba/Transforms/CallLowering.hpp"
 #include "numba/Transforms/CastUtils.hpp"
 #include "numba/Transforms/CommonOpts.hpp"
+#include "numba/Transforms/CompositePass.hpp"
 #include "numba/Transforms/PipelineUtils.hpp"
 #include "numba/Transforms/RewriteWrapper.hpp"
 #include "numba/Transforms/TypeConversion.hpp"
@@ -1958,9 +1959,11 @@ static mlir::spirv::TargetEnvAttr deviceCapsMapper(mlir::gpu::GPUModuleOp op) {
 }
 
 static void commonOptPasses(mlir::OpPassManager &pm) {
-  pm.addPass(numba::createCommonOptsPass());
-  pm.addPass(mlir::createCSEPass());
-  pm.addPass(numba::createCommonOptsPass());
+  pm.addPass(numba::createCompositePass(
+      "LowerGpuCommonOptPass", [](mlir::OpPassManager &p) {
+        p.addPass(mlir::createCSEPass());
+        p.addPass(numba::createCommonOptsPass());
+      }));
 }
 
 static void populateLowerToGPUPipelineHigh(mlir::OpPassManager &pm) {

--- a/numba_mlir_gpu_common/LevelZeroWrapper.hpp
+++ b/numba_mlir_gpu_common/LevelZeroWrapper.hpp
@@ -161,9 +161,8 @@ struct Module : public detail::Type<ze_module_handle_t, zeModuleDestroy> {
           std::string log;
           log.resize(size + 1);
           log[0] = '\n';
-          // TODO: need C++17 for std::string mutable data
-          CHECK_ZE_RESULT(zeModuleBuildLogGetString(
-              bl.get(), &size, const_cast<char *>(log.data()) + 1));
+          CHECK_ZE_RESULT(
+              zeModuleBuildLogGetString(bl.get(), &size, log.data() + 1));
           if (log.back() == '\0')
             log.pop_back();
           return log;


### PR DESCRIPTION
* Move `GenGlobalId` from gpu dialect canonicalizations to common opts
* Use `createCompositePass` in gpu lowering opt (will run set of passes until fixed point is reached)
* Remove const cast