### PR TITLE
Conda package fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -802,7 +802,7 @@ jobs:
           export LEVEL_ZERO_DIR=/home/runner/work/level-zero/level-zero/level_zero_install
           export LEVEL_ZERO_VERSION_CHECK_OFF=1
           export NUMBA_MLIR_USE_SYCL=ON
-          conda build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c intel || exit 1
+          conda build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c intel -c conda-forge || exit 1
           cd linux-64
           ls -l --block-size=M
           popd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -436,7 +436,7 @@ jobs:
           $env:CXX="cl.exe"
           $env:CC="cl.exe"
           $env:VSCMD_DEBUG = 3
-          conda build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c intel
+          conda build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c nodefaults -c intel
           cd win-64
           ls .
           popd
@@ -800,7 +800,7 @@ jobs:
           export LEVEL_ZERO_DIR=/home/runner/work/level-zero/level-zero/level_zero_install
           export LEVEL_ZERO_VERSION_CHECK_OFF=1
           export NUMBA_MLIR_USE_SYCL=ON
-          conda build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c intel || exit 1
+          conda build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c nodefaults -c intel || exit 1
           cd linux-64
           ls -l --block-size=M
           popd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -416,7 +416,6 @@ jobs:
 
       - name: Build conda package
         run: |
-          conda config --set channel_priority strict
           conda create -y -n test-env python=${{ matrix.python }} "pip>=22" numba=0.56 numpy=1.22 "setuptools<65.6" scikit-learn pytest-xdist ninja scipy pybind11 pytest "tbb=$env:TBB_VER" cmake "mkl-devel-dpcpp>=2023.0.0" conda-build conda-verify zlib dpcpp_win-64 -c conda-forge -c intel
           conda info
           mkdir numba_mlir_conda
@@ -793,7 +792,6 @@ jobs:
         shell: bash -l {0}
 
         run: |
-          conda config --set channel_priority strict
           mkdir numba_mlir_conda
           pushd numba_mlir_conda
           source $CONDA/bin/activate test-env

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -436,7 +436,7 @@ jobs:
           $env:CXX="cl.exe"
           $env:CC="cl.exe"
           $env:VSCMD_DEBUG = 3
-          conda build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c nodefaults -c intel
+          conda build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c intel
           cd win-64
           ls .
           popd
@@ -800,7 +800,7 @@ jobs:
           export LEVEL_ZERO_DIR=/home/runner/work/level-zero/level-zero/level_zero_install
           export LEVEL_ZERO_VERSION_CHECK_OFF=1
           export NUMBA_MLIR_USE_SYCL=ON
-          conda build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c nodefaults -c intel || exit 1
+          conda build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c intel || exit 1
           cd linux-64
           ls -l --block-size=M
           popd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -814,7 +814,7 @@ jobs:
 
         run: |
           cd numba_mlir_conda/linux-64
-          conda create -y -n conda-test-env python=${{ matrix.python }} numba=0.56 numpy=1.22 "setuptools<65.6" scikit-learn pytest-xdist ninja scipy pybind11 pytest tbb=${TBB_VER} cmake "mkl-devel-dpcpp>=2023.0.0" dpcpp_linux-64 -c conda-forge -c intel
+          conda create -y -n conda-test-env python=${{ matrix.python }} numba=0.56 numpy=1.22 scikit-learn pytest-xdist scipy pytest tbb=${TBB_VER} "mkl-dpcpp>=2023.0.0" "dpcpp-cpp-rt>=2023.0.0" -c intel -c conda-forge
           conda info
           source $CONDA/bin/activate conda-test-env
           conda list

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -416,6 +416,7 @@ jobs:
 
       - name: Build conda package
         run: |
+          conda config --set channel_priority strict
           conda create -y -n test-env python=${{ matrix.python }} "pip>=22" numba=0.56 numpy=1.22 "setuptools<65.6" scikit-learn pytest-xdist ninja scipy pybind11 pytest "tbb=$env:TBB_VER" cmake "mkl-devel-dpcpp>=2023.0.0" conda-build conda-verify zlib dpcpp_win-64 -c conda-forge -c intel
           conda info
           mkdir numba_mlir_conda
@@ -792,6 +793,7 @@ jobs:
         shell: bash -l {0}
 
         run: |
+          conda config --set channel_priority strict
           mkdir numba_mlir_conda
           pushd numba_mlir_conda
           source $CONDA/bin/activate test-env

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -417,7 +417,7 @@ jobs:
       - name: Build conda package
         run: |
           conda config --set channel_priority strict
-          conda create -y -n test-env python=${{ matrix.python }} "pip>=22" numba=0.56 numpy=1.22 "setuptools<65.6" scikit-learn pytest-xdist ninja scipy pybind11 pytest "tbb=$env:TBB_VER" cmake "mkl-devel-dpcpp>=2023.0.0" conda-build conda-verify zlib dpcpp_win-64 -c conda-forge -c intel
+          conda create -y -n test-env python=${{ matrix.python }} conda-build conda-verify boa -c conda-forge
           conda info
           mkdir numba_mlir_conda
           pushd numba_mlir_conda
@@ -437,7 +437,7 @@ jobs:
           $env:CXX="cl.exe"
           $env:CC="cl.exe"
           $env:VSCMD_DEBUG = 3
-          conda build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c intel
+          conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c intel
           cd win-64
           ls .
           popd
@@ -794,15 +794,16 @@ jobs:
 
         run: |
           conda config --set channel_priority strict
+          conda create -y -n package-test-env python=${{ matrix.python }} conda-build conda-verify boa -c conda-forge
           mkdir numba_mlir_conda
           pushd numba_mlir_conda
-          source $CONDA/bin/activate test-env
+          source $CONDA/bin/activate package-test-env
           export TBB_PATH=/home/runner/work/tbb/oneapi-tbb-${TBB_VER}
           export LLVM_PATH=/home/runner/work/llvm-mlir/_mlir_install
           export LEVEL_ZERO_DIR=/home/runner/work/level-zero/level-zero/level_zero_install
           export LEVEL_ZERO_VERSION_CHECK_OFF=1
           export NUMBA_MLIR_USE_SYCL=ON
-          conda build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c intel -c conda-forge || exit 1
+          conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c intel -c conda-forge || exit 1
           cd linux-64
           ls -l --block-size=M
           popd


### PR DESCRIPTION
Add `-c conda-forge` to conda build command on linux, so it will use compiler from there instead of system one