### PR TITLE
Fix numba .57 for py 3.8, 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,13 +211,6 @@ jobs:
     strategy:
       matrix:
         python: ["3.8", "3.9", "3.10"]
-        is_main:
-          - ${{ github.ref == 'refs/heads/main' }}
-        exclude:
-          - is_main: false
-            python: "3.8"
-          - is_main: false
-            python: "3.9"
 
     steps:
       - uses: ilammy/msvc-dev-cmd@v1
@@ -354,13 +347,6 @@ jobs:
     strategy:
       matrix:
         python: ["3.8", "3.9", "3.10"]
-        is_main:
-          - ${{ github.ref == 'refs/heads/main' }}
-        exclude:
-          - is_main: false
-            python: "3.8"
-          - is_main: false
-            python: "3.9"
 
     steps:
       - name: Cancel Previous Runs
@@ -658,13 +644,6 @@ jobs:
     strategy:
       matrix:
         python: ["3.8", "3.9", "3.10"]
-        is_main:
-          - ${{ github.ref == 'refs/heads/main' }}
-        exclude:
-          - is_main: false
-            python: "3.8"
-          - is_main: false
-            python: "3.9"
 
     steps:
       - name: Cancel Previous Runs

--- a/numba_mlir/numba_mlir/mlir/passes.py
+++ b/numba_mlir/numba_mlir/mlir/passes.py
@@ -76,6 +76,14 @@ class MlirBackendBase(FunctionPass):
             func_registry.push_active_funcs_stack()
             try:
                 res = self.run_pass_impl(state)
+            except:
+                print("=============== pass failed, func ir ==================")
+                state.func_ir.dump()
+                print(
+                    "============= pass failed, func ir end ================",
+                    flush=True,
+                )
+                raise
             finally:
                 func_registry.pop_active_funcs_stack()
             return res

--- a/numba_mlir/numba_mlir/mlir/passes.py
+++ b/numba_mlir/numba_mlir/mlir/passes.py
@@ -76,14 +76,6 @@ class MlirBackendBase(FunctionPass):
             func_registry.push_active_funcs_stack()
             try:
                 res = self.run_pass_impl(state)
-            except:
-                print("=============== pass failed, func ir ==================")
-                state.func_ir.dump()
-                print(
-                    "============= pass failed, func ir end ================",
-                    flush=True,
-                )
-                raise
             finally:
                 func_registry.pop_active_funcs_stack()
             return res

--- a/numba_mlir/numba_mlir/mlir/tests/test_numba_parfor.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numba_parfor.py
@@ -125,6 +125,9 @@ def _gen_tests():
         "test_three_d_array_reduction",  # We intentionally do not detect data races
         "test_two_d_array_reduction_reuse",  # We intentionally do not detect data races
         "test_two_d_array_reduction",  # We intentionally do not detect data races
+        "test_parfor_slice27 ",  # Invalid phi in input IR
+        "test_parfor_array_access2",  # Invalid phi in input IR
+        "test_prange_nested_reduction1",  # Invalid phi in input IR
     }
 
     def countParfors(test_func, args, **kws):

--- a/numba_mlir/numba_mlir/mlir/tests/test_numba_parfor.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numba_parfor.py
@@ -125,7 +125,7 @@ def _gen_tests():
         "test_three_d_array_reduction",  # We intentionally do not detect data races
         "test_two_d_array_reduction_reuse",  # We intentionally do not detect data races
         "test_two_d_array_reduction",  # We intentionally do not detect data races
-        "test_parfor_slice27 ",  # Invalid phi in input IR
+        "test_parfor_slice27",  # Invalid phi in input IR
         "test_parfor_array_access2",  # Invalid phi in input IR
         "test_prange_nested_reduction1",  # Invalid phi in input IR
     }

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -749,8 +749,6 @@ private:
         op.erase();
         builder.create<mlir::cf::CondBranchOp>(loc, cond, trueDest, trueArgs,
                                                falseDest, falseArgs);
-      } else if (mlir::isa<mlir::func::ReturnOp>(term)) {
-        // Nothing
       } else {
         numba::reportError(llvm::Twine("Unhandled terminator: ") +
                            term->getName().getStringRef());

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -731,8 +731,6 @@ private:
         op.erase();
         builder.create<mlir::cf::CondBranchOp>(loc, cond, trueDest, trueArgs,
                                                falseDest, falseArgs);
-      } else if (mlir::isa<mlir::func::ReturnOp>(term)) {
-        // Nothing
       } else {
         numba::reportError(llvm::Twine("Unhandled terminator: ") +
                            term->getName().getStringRef());

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -731,6 +731,8 @@ private:
         op.erase();
         builder.create<mlir::cf::CondBranchOp>(loc, cond, trueDest, trueArgs,
                                                falseDest, falseArgs);
+      } else if (mlir::isa<mlir::func::ReturnOp>(term)) {
+        // Nothing
       } else {
         numba::reportError(llvm::Twine("Unhandled terminator: ") +
                            term->getName().getStringRef());


### PR DESCRIPTION
* Run py 3.8, 3.9 tests on PR
* Skip failing parfor tests (invalid PHI in numba IR, need to investigate)
* Some lowering refactoring