### PR TITLE
Fix tuple arg handling in nested ops

### DIFF
--- a/mlir/lib/Dialect/numba_util/Dialect.cpp
+++ b/mlir/lib/Dialect/numba_util/Dialect.cpp
@@ -1597,7 +1597,7 @@ struct SignCastIfPropagate : public mlir::OpRewritePattern<mlir::scf::IfOp> {
     auto thenYield = op.thenYield();
     auto elseYield = op.elseYield();
 
-    unsigned idx;
+    unsigned idx = 0;
     CastOp castOp;
     numba::util::UndefOp undefOp;
     for (auto &&[i, args] : llvm::enumerate(

--- a/numba_mlir/numba_mlir/mlir/inner_compiler.py
+++ b/numba_mlir/numba_mlir/mlir/inner_compiler.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from numba.core.untyped_passes import ReconstructSSA
-from numba.core.typed_passes import NopythonTypeInference, AnnotateTypes
+from numba.core.typed_passes import NopythonTypeInference
 from numba.core.compiler import (
     CompilerBase,
     DefaultPassBuilder,
@@ -26,7 +26,6 @@ class MlirTempCompiler(CompilerBase):  # custom compiler extends from CompilerBa
 
         pm.add_pass(ReconstructSSA, "ssa")
         pm.add_pass(NopythonTypeInference, "nopython frontend")
-        pm.add_pass(AnnotateTypes, "annotate types")
         pm.add_pass(MlirBackendInner, "mlir backend")
 
         pm.finalize()

--- a/numba_mlir/numba_mlir/mlir/tests/test_basic.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_basic.py
@@ -408,6 +408,20 @@ def test_indirect_call_inline():
         assert ir.count("call @") == 0, ir
 
 
+@pytest.mark.parametrize("arg", [(), (1,), (1, 2), (1, 2.5)])
+def test_indirect_call_tuple(arg):
+    def inner_func(a):
+        return a
+
+    def func(func, a):
+        return func(a)
+
+    jit_inner_func = njit(inner_func)
+    jit_func = njit(func)
+
+    assert_equal(func(inner_func, arg), jit_func(jit_inner_func, arg))
+
+
 def test_none_args():
     def py_func(a, b, c, d):
         return b + d

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/PyMapTypes.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/PyMapTypes.cpp
@@ -96,15 +96,16 @@ static py::object mapType(const py::handle &typesMod, mlir::Type type) {
   }
 
   if (auto t = type.dyn_cast<mlir::TupleType>()) {
-    py::tuple ret(t.size());
+    py::tuple types(t.size());
     for (auto &&[i, val] : llvm::enumerate(t.getTypes())) {
       auto inner = mapType(typesMod, val);
       if (!inner)
         return {};
 
-      ret[i] = std::move(inner);
+      types[i] = std::move(inner);
     }
-    return std::move(ret);
+    auto tupleType = typesMod.attr("Tuple");
+    return tupleType(types);
   }
 
   if (auto dtype = type.dyn_cast<numba::util::TypeVarType>()) {

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToStd.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToStd.cpp
@@ -858,9 +858,8 @@ protected:
     auto kwn = op.getKwNames();
     llvm::SmallVector<llvm::StringRef> kwNames;
     kwNames.reserve(kwn.size());
-    for (auto name : kwn.getAsValueRange<mlir::StringAttr>()) {
+    for (auto name : kwn.getAsValueRange<mlir::StringAttr>())
       kwNames.emplace_back(name);
-    }
 
     auto mod = op->getParentOfType<mlir::ModuleOp>();
     assert(mod);


### PR DESCRIPTION
* need to use `numba.Types.Tuple` instead of python `tuple`
* Fix potentially uninitialized var warning
* Remove unneeded `AnnotateTypes` numba pass
* Some style fixes