### PR TITLE
Fastmath handling refactoring

### DIFF
--- a/mlir/lib/Transforms/UpliftMath.cpp
+++ b/mlir/lib/Transforms/UpliftMath.cpp
@@ -4,8 +4,6 @@
 
 #include "numba/Transforms/UpliftMath.hpp"
 
-#include "numba/Dialect/numba_util/Dialect.hpp"
-
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Complex/IR/Complex.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>


### PR DESCRIPTION
* Propagate fastmath flags on arith level instead of llvm
* Uplift FMA based on ops flags instead of func flags