### PR TITLE
Do not allocate mkl gpu gemm arg as `host_shared`

### DIFF
--- a/mlir/include/numba/Dialect/gpu_runtime/IR/GpuRuntimeOps.hpp
+++ b/mlir/include/numba/Dialect/gpu_runtime/IR/GpuRuntimeOps.hpp
@@ -31,6 +31,7 @@ namespace gpu_runtime {
 mlir::StringRef getGpuAccessibleAttrName();
 mlir::StringRef getFenceFlagsAttrName();
 mlir::StringRef getFp64TruncateAttrName();
+mlir::StringRef getDeviceFuncAttrName();
 
 enum class FenceFlags : int64_t {
   local = 1,

--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -1648,8 +1648,7 @@ struct ExpandDeviceFuncCallOp
     newArgs.emplace_back(*stream);
     newArgs.append(oldArgs.begin(), oldArgs.end());
 
-    auto call = rewriter.replaceOpWithNewOp<mlir::func::CallOp>(op, deviceFunc,
-                                                                newArgs);
+    rewriter.replaceOpWithNewOp<mlir::func::CallOp>(op, deviceFunc, newArgs);
     return mlir::success();
   }
 };

--- a/mlir/lib/Dialect/gpu_runtime/IR/GpuRuntimeOps.cpp
+++ b/mlir/lib/Dialect/gpu_runtime/IR/GpuRuntimeOps.cpp
@@ -218,6 +218,8 @@ mlir::StringRef getFenceFlagsAttrName() { return "gpu_runtime.fence_flags"; }
 mlir::StringRef getFp64TruncateAttrName() {
   return "gpu_runtime.fp64_truncate";
 }
+
+mlir::StringRef getDeviceFuncAttrName() { return "gpu_runtime.device_func"; }
 } // namespace gpu_runtime
 
 // TODO: unify with upstream

--- a/numba_mlir/numba_mlir/mlir/numpy/funcs.py
+++ b/numba_mlir/numba_mlir/mlir/numpy/funcs.py
@@ -581,7 +581,7 @@ def _mkl_gemm(builder, a, b, alpha, beta, shape1, shape2):
     c = builder.init_tensor(res_shape, dtype)
 
     return builder.external_call(
-        func_name, (a, b), c, attrs={"device_func": device_func_name}
+        func_name, (a, b), c, attrs={"gpu_runtime.device_func": device_func_name}
     )
 
 


### PR DESCRIPTION
* Before all function calls were to considered as host read/write
* Add check for `device_func` attr, so functions executed on gpu (e.g. mkl gpu gemm) will be considered device read/write
* Allows to remove `host_shared` flag from gemm args allocation
