### PR TITLE
Atomic lowering refactoring

### DIFF
--- a/mlir/include/numba/Transforms/CastUtils.hpp
+++ b/mlir/include/numba/Transforms/CastUtils.hpp
@@ -10,6 +10,7 @@ class Location;
 class OpBuilder;
 class Type;
 class IntegerType;
+class MemRefType;
 } // namespace mlir
 
 namespace numba {
@@ -20,6 +21,7 @@ mlir::Value indexCast(mlir::OpBuilder &builder, mlir::Location loc,
 
 mlir::Type makeSignlessType(mlir::Type type);
 mlir::IntegerType makeSignlessType(mlir::IntegerType type);
+mlir::MemRefType makeSignlessType(mlir::MemRefType type);
 
 bool canConvert(mlir::Type srcType, mlir::Type dstType);
 mlir::Value doConvert(mlir::OpBuilder &rewriter, mlir::Location loc,

--- a/mlir/lib/Transforms/CastUtils.cpp
+++ b/mlir/lib/Transforms/CastUtils.cpp
@@ -48,12 +48,24 @@ mlir::Type numba::makeSignlessType(mlir::Type type) {
   if (auto intType = type.dyn_cast<mlir::IntegerType>())
     return makeSignlessType(intType);
 
+  if (auto memrefType = type.dyn_cast<mlir::MemRefType>())
+    return makeSignlessType(memrefType);
+
   return type;
 }
 
 mlir::IntegerType numba::makeSignlessType(mlir::IntegerType type) {
   if (!type.isSignless())
     return mlir::IntegerType::get(type.getContext(), type.getWidth());
+
+  return type;
+}
+
+mlir::MemRefType numba::makeSignlessType(mlir::MemRefType type) {
+  auto oldElemType = type.getElementType();
+  auto newElemType = makeSignlessType(oldElemType);
+  if (newElemType != oldElemType)
+    return mlir::cast<mlir::MemRefType>(type.clone(newElemType));
 
   return type;
 }


### PR DESCRIPTION
* Convert atomic call to `AtomicRMWOp` early
* Add corresponding `AtomicRMWOp` llvm and spirv lowering
* Some `SignCastOp` and `ChangeLayoutOp` propagation improvements