### PR TITLE
Add array dimensions count to atomic function name

### DIFF
--- a/numba_mlir/numba_mlir/mlir/kernel_impl.py
+++ b/numba_mlir/numba_mlir/mlir/kernel_impl.py
@@ -256,7 +256,7 @@ def _define_atomic_funcs():
 
                 dtype = arr.dtype
                 val = builder.cast(-val, dtype)
-                fname = f"atomic_add_{dtype_str(builder, dtype)}"
+                fname = f"atomic_add_{dtype_str(builder, dtype)}_{len(arr.shape)}"
                 return builder.external_call(fname, (arr, val), val)
 
         else:
@@ -267,7 +267,7 @@ def _define_atomic_funcs():
 
                 dtype = arr.dtype
                 val = builder.cast(val, dtype)
-                fname = f"{func_name}_{dtype_str(builder, dtype)}"
+                fname = f"{func_name}_{dtype_str(builder, dtype)}_{len(arr.shape)}"
                 return builder.external_call(fname, (arr, val), val)
 
         return api_func_impl


### PR DESCRIPTION
Add dimensions count to names of atomic functions to avoid conflicts when atomic functions applied to arrays with different dimensions count in the same kernel.
