### PR TITLE
Fix arry settitem broadcasting

### DIFF
--- a/mlir/include/numba/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/numba/Dialect/ntensor/IR/NTensorOps.td
@@ -771,6 +771,10 @@ def BroadcastOp : NTensor_OpBase<"broadcast", [
   let assemblyFormat =
     "attr-dict `(` $inputs `)` `:`  qualified(type($inputs)) `->` qualified(type($results))";
 
+  let builders = [
+    OpBuilder<(ins "::mlir::ValueRange":$inputs)>
+  ];
+
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }

--- a/mlir/lib/Dialect/ntensor/IR/NTensorOps.cpp
+++ b/mlir/lib/Dialect/ntensor/IR/NTensorOps.cpp
@@ -889,14 +889,18 @@ void numba::ntensor::BroadcastOp::build(::mlir::OpBuilder &odsBuilder,
   for (auto &&arg : inputs) {
     auto type = mlir::cast<mlir::ShapedType>(arg.getType());
     auto shape = type.getShape();
-    if (shape.size() > newShape.size())
-      newShape.resize(shape.size(), mlir::ShapedType::kDynamic);
+    if (shape.size() > newShape.size()) {
+      size_t diff = shape.size() - newShape.size();
+      newShape.insert(newShape.begin(), diff, mlir::ShapedType::kDynamic);
+    }
 
     for (auto &&[i, dim] : llvm::enumerate(shape)) {
-      auto oldDim = newShape[i];
+      auto diff =
+          shape.size() < newShape.size() ? newShape.size() - shape.size() : 0;
+      auto oldDim = newShape[diff + i];
       assert(areDimsBroadcastable(oldDim, dim));
       auto newDim = isDynamicOrUnit(oldDim) ? dim : oldDim;
-      newShape[i] = newDim;
+      newShape[diff + i] = newDim;
     }
   }
 

--- a/mlir/lib/Dialect/ntensor/Transforms/ResolveArrayOps.cpp
+++ b/mlir/lib/Dialect/ntensor/Transforms/ResolveArrayOps.cpp
@@ -278,6 +278,10 @@ struct SetitemOpLowering
         return rewriter.create<numba::ntensor::CreateArrayOp>(
             loc, dstType, dynamicDims, dstVal);
       }();
+      mlir::Value broadcastArgs[] = {newArray, dst};
+      auto broadcast =
+          rewriter.create<numba::ntensor::BroadcastOp>(loc, broadcastArgs);
+      newArray = broadcast.getResult(0);
       rewriter.replaceOpWithNewOp<numba::ntensor::CopyOp>(op, newArray, dst);
     } else {
       // Is single element

--- a/mlir/lib/Dialect/ntensor/Transforms/ResolveArrayOps.cpp
+++ b/mlir/lib/Dialect/ntensor/Transforms/ResolveArrayOps.cpp
@@ -246,6 +246,8 @@ struct SetitemOpLowering
         if (auto srcType =
                 value.getType().dyn_cast<numba::ntensor::NTensorType>()) {
           auto dstElementType = targetType.getElementType();
+          auto dstType = srcType.clone(dstElementType);
+          mlir::Value res = value;
           if (srcType.getElementType() != dstElementType) {
             auto bodyBuilder = [&](mlir::OpBuilder &b, mlir::Location l,
                                    mlir::ValueRange vals) {
@@ -255,12 +257,12 @@ struct SetitemOpLowering
               b.create<numba::ntensor::ElementwiseYieldOp>(l, res);
             };
 
-            return rewriter
-                .create<numba::ntensor::ElementwiseOp>(loc, targetType, value,
-                                                       bodyBuilder)
-                .getResult(0);
+            res = rewriter
+                      .create<numba::ntensor::ElementwiseOp>(loc, dstType,
+                                                             value, bodyBuilder)
+                      .getResult(0);
           }
-          return value;
+          return res;
         }
 
         auto dstType = dst.getType().cast<numba::ntensor::NTensorType>();

--- a/mlir/lib/Transforms/CommonOpts.cpp
+++ b/mlir/lib/Transforms/CommonOpts.cpp
@@ -162,39 +162,6 @@ struct AndConflictSimplify
   }
 };
 
-struct CmpiOfSelect : public mlir::OpRewritePattern<mlir::arith::CmpIOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  mlir::LogicalResult
-  matchAndRewrite(mlir::arith::CmpIOp op,
-                  mlir::PatternRewriter &rewriter) const override {
-    using Pred = mlir::arith::CmpIPredicate;
-    auto predicate = op.getPredicate();
-    if (predicate != Pred::eq && predicate != Pred::ne)
-      return mlir::failure();
-
-    for (bool reverse1 : {false, true}) {
-      auto select = (reverse1 ? op.getRhs() : op.getLhs())
-                        .getDefiningOp<mlir::arith::SelectOp>();
-      if (!select)
-        continue;
-
-      auto other = (reverse1 ? op.getLhs() : op.getRhs());
-      for (bool reverse2 : {false, true}) {
-        auto selectArg(reverse2 ? select.getFalseValue()
-                                : select.getTrueValue());
-        if (other != selectArg)
-          continue;
-
-        bool res = static_cast<int64_t>(reverse2 != (predicate == Pred::ne));
-        rewriter.replaceOpWithNewOp<mlir::arith::ConstantIntOp>(op, res, 1);
-        return mlir::success();
-      }
-    }
-    return mlir::failure();
-  }
-};
-
 // TODO: upstream
 struct XorOfCmpF : public mlir::OpRewritePattern<mlir::arith::XOrIOp> {
   using OpRewritePattern::OpRewritePattern;
@@ -462,7 +429,6 @@ void numba::populateCommonOptsPatterns(mlir::RewritePatternSet &patterns) {
       SubviewStorePropagate,
       PowSimplify,
       AndConflictSimplify,
-      CmpiOfSelect,
       XorOfCmpF,
       ExtractStridedMetadataUnused,
       ExtractStridedMetadataConstStrides,

--- a/mlir/test/Dialect/ntensor/resolve-array-ops.mlir
+++ b/mlir/test/Dialect/ntensor/resolve-array-ops.mlir
@@ -116,7 +116,8 @@ func.func @test(%arg1: !ntensor.ntensor<?xf32>, %arg2: !ntensor.slice, %arg3: f3
 //  CHECK-NEXT:   %[[RES:.*]] = ntensor.subview %[[ARG1]][%[[BEGIN]]] [%[[COUNT]]] [%[[STEP]]] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
 //  CHECK-NEXT:   %[[DIM2:.*]] = ntensor.dim %[[RES]], %[[C0]] : !ntensor.ntensor<?xf32>
 //  CHECK-NEXT:   %[[RES2:.*]] = ntensor.create(%[[DIM2]]) = (%[[ARG3]] : f32) : !ntensor.ntensor<?xf32>
-//  CHECK-NEXT:   ntensor.copy %[[RES2]], %[[RES]] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
+//  CHECK-NEXT:   %[[BC:.*]]:2 = ntensor.broadcast(%[[RES2]], %[[RES]]) : !ntensor.ntensor<?xf32>, !ntensor.ntensor<?xf32> -> !ntensor.ntensor<?xf32>, !ntensor.ntensor<?xf32>
+//  CHECK-NEXT:   ntensor.copy %[[BC]]#0, %[[RES]] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
 //  CHECK-NEXT:   return
 
 // -----
@@ -169,7 +170,8 @@ func.func @test(%arg1: !ntensor.ntensor<?xf32>, %arg2: !ntensor.slice, %arg3: !n
 //  CHECK-NEXT:   %[[DIM:.*]] = ntensor.dim %[[ARG1]], %[[C0]] : !ntensor.ntensor<?xf32>
 //  CHECK-NEXT:   %[[BEGIN:.*]], %[[END:.*]], %[[STEP:.*]], %[[COUNT:.*]] = ntensor.resolve_slice %[[ARG2]], %[[DIM]]
 //  CHECK-NEXT:   %[[RES:.*]] = ntensor.subview %[[ARG1]][%[[BEGIN]]] [%[[COUNT]]] [%[[STEP]]] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
-//  CHECK-NEXT:   ntensor.copy %[[ARG3]], %[[RES]] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
+//  CHECK-NEXT:   %[[BC:.*]]:2 = ntensor.broadcast(%[[ARG3]], %[[RES]]) : !ntensor.ntensor<?xf32>, !ntensor.ntensor<?xf32> -> !ntensor.ntensor<?xf32>, !ntensor.ntensor<?xf32>
+//  CHECK-NEXT:   ntensor.copy %[[BC]]#0, %[[RES]] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
 //  CHECK-NEXT:   return
 
 // -----
@@ -190,7 +192,8 @@ func.func @test(%arg1: !ntensor.ntensor<?x?xf32>, %arg2: tuple<!ntensor.slice, i
 //  CHECK-NEXT:   %[[IDX3:.*]] = ntensor.resolve_index %[[IDX2]], %[[DIM2]]
 //  CHECK-NEXT:   %[[RES1:.*]] = ntensor.subview %[[ARG1]][%[[BEGIN]], %[[IDX3]]] [%[[COUNT]], 1] [%[[STEP]], 1] : !ntensor.ntensor<?x?xf32> to !ntensor.ntensor<?x1xf32>
 //  CHECK-NEXT:   %[[RES2:.*]]  = ntensor.subview %[[RES1]][0, 0] [%[[COUNT]], 1] [1, 1] : !ntensor.ntensor<?x1xf32> to !ntensor.ntensor<?xf32>
-//  CHECK-NEXT:   ntensor.copy %[[ARG3]], %[[RES2]] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
+//  CHECK-NEXT:   %[[BC:.*]]:2 = ntensor.broadcast(%[[ARG3]], %[[RES2]]) : !ntensor.ntensor<?xf32>, !ntensor.ntensor<?xf32> -> !ntensor.ntensor<?xf32>, !ntensor.ntensor<?xf32>
+//  CHECK-NEXT:   ntensor.copy %[[BC]]#0, %[[RES2]] : !ntensor.ntensor<?xf32> to !ntensor.ntensor<?xf32>
 //  CHECK-NEXT:   return
 
 
@@ -230,7 +233,8 @@ func.func @test(%arg1: !ntensor.ntensor<?xf64>, %arg2: !ntensor.slice, %arg3: !n
 //  CHECK-NEXT:   %[[V:.*]] = arith.extf %[[ARG4]] : f32 to f64
 //  CHECK-NEXT:   ntensor.elementwise_yield %[[V]]  : f64
 //  CHECK-NEXT:   }
-//  CHECK-NEXT:   ntensor.copy %[[RES1]], %[[RES]] : !ntensor.ntensor<?xf64> to !ntensor.ntensor<?xf64>
+//  CHECK-NEXT:   %[[BC:.*]]:2 = ntensor.broadcast(%[[RES1]], %[[RES]]) : !ntensor.ntensor<?xf64>, !ntensor.ntensor<?xf64> -> !ntensor.ntensor<?xf64>, !ntensor.ntensor<?xf64>
+//  CHECK-NEXT:   ntensor.copy %[[BC]]#0, %[[RES]] : !ntensor.ntensor<?xf64> to !ntensor.ntensor<?xf64>
 //  CHECK-NEXT:   return
 
 // -----
@@ -248,7 +252,8 @@ func.func @test(%arg1: !ntensor.ntensor<?xf64>, %arg2: !ntensor.slice, %arg3: f3
 //  CHECK-NEXT:   %[[DIM2:.*]] = ntensor.dim %[[RES]], %[[C0]] : !ntensor.ntensor<?xf64>
 //  CHECK-NEXT:   %[[CONV:.*]] = arith.extf %[[ARG3]] : f32 to f64
 //  CHECK-NEXT:   %[[RES2:.*]] = ntensor.create(%[[DIM2]]) = (%[[CONV]] : f64) : !ntensor.ntensor<?xf64>
-//  CHECK-NEXT:   ntensor.copy %[[RES2]], %[[RES]] : !ntensor.ntensor<?xf64> to !ntensor.ntensor<?xf64>
+//  CHECK-NEXT:   %[[BC:.*]]:2 = ntensor.broadcast(%[[RES2]], %[[RES]]) : !ntensor.ntensor<?xf64>, !ntensor.ntensor<?xf64> -> !ntensor.ntensor<?xf64>, !ntensor.ntensor<?xf64>
+//  CHECK-NEXT:   ntensor.copy %[[BC]]#0, %[[RES]] : !ntensor.ntensor<?xf64> to !ntensor.ntensor<?xf64>
 //  CHECK-NEXT:   return
 
 // -----

--- a/numba_mlir/numba_mlir/mlir/tests/test_numba_parfor.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numba_parfor.py
@@ -112,7 +112,6 @@ def _gen_tests():
         "test_tuple_for_pndindex",
         "test_tuple_of_literal_nonliteral",
         "test_if_not_else_reduction",
-        "test_prange30",
         "test_int_arg_pndindex",
         "test_non_identity_initial",
         "test_prange_optional",

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
@@ -313,7 +313,8 @@ def test_broadcast(a, b):
 
 
 @pytest.mark.parametrize(
-    "a_shape, b_shape", [((2, 3, 4), (2, 1, 4)), ((1, 2, 3), (1, 1))]
+    "a_shape, b_shape",
+    [((2, 3, 4), (2, 1, 4)), ((1, 2, 3), (1, 1)), ((2, 3, 4), (3, 4))],
 )
 def test_broadcast_setitem(a_shape, b_shape):
     def py_func(a, b):

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
@@ -312,6 +312,20 @@ def test_broadcast(a, b):
     assert_equal(py_func(a, b), jit_func(a, b))
 
 
+@pytest.mark.parametrize("a_shape, b_shape", [((2, 3, 4), (2, 1, 4))])
+def test_broadcast_setitem(a_shape, b_shape):
+    def py_func(a, b):
+        a[:] = b
+        return a
+
+    jit_func = njit(py_func)
+
+    a = np.zeros(a_shape)
+    b = np.arange(math.prod(b_shape)).reshape(b_shape)
+
+    assert_equal(py_func(a.copy(), b), jit_func(a.copy(), b))
+
+
 @pytest.mark.parametrize("a", [np.arange(3 * 4 * 5).reshape(3, 4, 5)])
 @parametrize_function_variants(
     "py_func",

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
@@ -312,7 +312,9 @@ def test_broadcast(a, b):
     assert_equal(py_func(a, b), jit_func(a, b))
 
 
-@pytest.mark.parametrize("a_shape, b_shape", [((2, 3, 4), (2, 1, 4))])
+@pytest.mark.parametrize(
+    "a_shape, b_shape", [((2, 3, 4), (2, 1, 4)), ((1, 2, 3), (1, 1))]
+)
 def test_broadcast_setitem(a_shape, b_shape):
     def py_func(a, b):
         a[:] = b


### PR DESCRIPTION
* Broadcast setitem arg
* Remove problematic `CmpiOfSelect` pattern (fixes 1 prange test)
* Add a proper constructor to `BroadcastOp` with shape inference
