### PR TITLE
Some fixes

### DIFF
--- a/mlir/include/numba/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/numba/Dialect/ntensor/IR/NTensorOps.td
@@ -595,6 +595,15 @@ def CreateArrayOp : NTensor_OpBase<"create", [AttrSizedOperandSegments, Pure]> {
   let results = (outs Res<NTensor_Tensor, "", [MemAlloc<DefaultResource>]>:$result);
 
   let assemblyFormat = "`(`$dynamicSizes`)` (`=` `(` $initValue^ `:` type($initValue) `)`)? attr-dict `:` qualified(type($result))";
+
+    let extraClassDeclaration = [{
+    // Return both static and dynamic sizes as a list of `OpFoldResult`.
+    ::llvm::SmallVector<::mlir::OpFoldResult> getMixedSizes();
+
+    // Return the Value of the dynamic size of the tensor at dimension `idx`.
+    // Asserts that the shape is dynamic at that `idx`.
+    ::mlir::Value getDynamicSize(unsigned idx);
+  }];
 }
 
 def FromTensorOp : NTensor_OpBase<"from_tensor",

--- a/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
+++ b/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
@@ -48,7 +48,7 @@ public:
   ShapeValue(mlir::ArrayAttr attr) : shapeRanges(std::in_place) {
     shapeRanges->reserve(attr.size());
     for (auto elem : attr) {
-      auto range = elem.cast<numba::util::IndexRangeAttr>();
+      auto range = mlir::cast<numba::util::IndexRangeAttr>(elem);
       shapeRanges->emplace_back(getIndexRange(range.getMin(), range.getMax()));
     }
   }
@@ -426,12 +426,12 @@ public:
         return;
 
       if (!llvm::all_of(generic.getIndexingMaps(), [](mlir::Attribute map) {
-            return map.cast<mlir::AffineMapAttr>().getValue().isIdentity();
+            return mlir::cast<mlir::AffineMapAttr>(map).getValue().isIdentity();
           }))
         return;
 
       if (!llvm::all_of(generic.getIteratorTypes(), [](mlir::Attribute map) {
-            return map.cast<mlir::linalg::IteratorTypeAttr>().getValue() ==
+            return mlir::cast<mlir::linalg::IteratorTypeAttr>(map).getValue() ==
                    mlir::utils::IteratorType::parallel;
           }))
 

--- a/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
+++ b/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
@@ -143,8 +143,8 @@ public:
 
     if (auto fromElements = mlir::dyn_cast<mlir::tensor::FromElementsOp>(op)) {
       assert(results.size() == 1);
-      auto tensorType =
-          fromElements.getResult().getType().cast<mlir::RankedTensorType>();
+      auto tensorType = mlir::cast<mlir::RankedTensorType>(
+          fromElements.getResult().getType());
       if (tensorType.getRank() != 1 ||
           mlir::ShapedType::isDynamic(tensorType.getShape().front()))
         return;
@@ -234,7 +234,7 @@ public:
         return;
 
       auto result = op->getResult(0);
-      auto shaped = result.getType().dyn_cast<mlir::ShapedType>();
+      auto shaped = mlir::dyn_cast<mlir::ShapedType>(result.getType());
       if (!shaped)
         return;
 
@@ -293,12 +293,12 @@ public:
 
     if (auto enforceShape = mlir::dyn_cast<numba::util::EnforceShapeOp>(op)) {
       auto srcShaped =
-          enforceShape.getValue().getType().dyn_cast<mlir::ShapedType>();
+          mlir::dyn_cast<mlir::ShapedType>(enforceShape.getValue().getType());
       if (!srcShaped)
         return;
 
       auto dstShaped =
-          enforceShape.getResult().getType().dyn_cast<mlir::ShapedType>();
+          mlir::dyn_cast<mlir::ShapedType>(enforceShape.getResult().getType());
       if (!dstShaped)
         return;
 
@@ -367,7 +367,7 @@ public:
 
       ShapeValue newVal(ranges);
 
-      auto shaped = empty.getResult().getType().cast<mlir::ShapedType>();
+      auto shaped = mlir::cast<mlir::ShapedType>(empty.getResult().getType());
       newVal = ShapeValue::intersect(newVal, {shaped});
 
       LLVM_DEBUG(llvm::dbgs()
@@ -407,7 +407,7 @@ public:
 
       ShapeValue newVal(ranges);
 
-      auto shaped = empty.getResult().getType().cast<mlir::ShapedType>();
+      auto shaped = mlir::cast<mlir::ShapedType>(empty.getResult().getType());
       newVal = ShapeValue::intersect(newVal, {shaped});
 
       LLVM_DEBUG(llvm::dbgs()
@@ -440,11 +440,11 @@ public:
       ShapeValue newVal;
       for (auto arg : op->getOperands())
         newVal = ShapeValue::intersect(
-            newVal, {arg.getType().cast<mlir::ShapedType>()});
+            newVal, {mlir::cast<mlir::ShapedType>(arg.getType())});
 
       for (auto result : op->getResults())
         newVal = ShapeValue::intersect(
-            newVal, {result.getType().cast<mlir::ShapedType>()});
+            newVal, {mlir::cast<mlir::ShapedType>(result.getType())});
 
       for (auto input : operands) {
         auto inpuLatticeVal = input->getValue();
@@ -511,7 +511,7 @@ public:
     }
 
     for (auto &&[res, resultLattice] : llvm::zip(op->getResults(), results)) {
-      auto shaped = res.getType().dyn_cast<mlir::ShapedType>();
+      auto shaped = mlir::dyn_cast<mlir::ShapedType>(res.getType());
       if (!shaped)
         continue;
 
@@ -541,7 +541,7 @@ public:
       auto &body = func.getFunctionBody();
       assert(!body.empty());
       for (auto &&[i, arg] : llvm::enumerate(body.front().getArguments())) {
-        auto shaped = arg.getType().dyn_cast<mlir::ShapedType>();
+        auto shaped = mlir::dyn_cast<mlir::ShapedType>(arg.getType());
         if (!shaped)
           continue;
 

--- a/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
+++ b/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
@@ -420,8 +420,9 @@ public:
       assert(operands.size() == 1);
       assert(results.size() == 1);
 
-      auto srcShaped = op->getOperand(0).getType().cast<mlir::ShapedType>();
-      auto dstShaped = op->getResult(0).getType().cast<mlir::ShapedType>();
+      auto srcShaped =
+          mlir::cast<mlir::ShapedType>(op->getOperand(0).getType());
+      auto dstShaped = mlir::cast<mlir::ShapedType>(op->getResult(0).getType());
       auto res =
           ShapeValue::intersect(ShapeValue{srcShaped}, ShapeValue{dstShaped});
       res = ShapeValue::intersect(operands.front()->getValue(), res);


### PR DESCRIPTION
* Add helper functions to `ntensor.create_array`
* Shape propagation pass check `isUninitialized`
* Shape propagation pass add `ntensor.create_array` support
