### PR TITLE
GPU events handling refactor

### DIFF
--- a/mlir/include/numba/Conversion/GpuRuntimeToLlvm.hpp
+++ b/mlir/include/numba/Conversion/GpuRuntimeToLlvm.hpp
@@ -14,9 +14,6 @@ class RewritePatternSet;
 } // namespace mlir
 
 namespace gpu_runtime {
-
-std::unique_ptr<mlir::Pass> createEnumerateEventsPass();
-
 /// Populates the given list with patterns that convert from gpu_runtime to
 /// LLVM.
 void populateGpuToLLVMPatternsAndLegality(mlir::LLVMTypeConverter &converter,

--- a/mlir/tools/level_zero_runner/LevelZeroRunner.cpp
+++ b/mlir/tools/level_zero_runner/LevelZeroRunner.cpp
@@ -84,8 +84,6 @@ static LogicalResult runMLIRPasses(mlir::Operation *op,
 
   // GpuRuntime -> LLVM
 
-  passManager.addPass(gpu_runtime::createEnumerateEventsPass());
-
   ConvertFuncToLLVMPassOptions llvmPassOptions;
   llvmPassOptions.dataLayout = llvmOptions.dataLayout.getStringRepresentation();
   passManager.addPass(createConvertFuncToLLVMPass(llvmPassOptions));

--- a/mlir/tools/numba-mlir-opt/Passes.cpp
+++ b/mlir/tools/numba-mlir-opt/Passes.cpp
@@ -84,12 +84,6 @@ static mlir::PassPipelineRegistration<> GpuToGpuRuntime(
     });
 
 static mlir::PassPipelineRegistration<>
-    EnumerateEvents("enumerate-events", "Adds event dependency",
-                    [](mlir::OpPassManager &pm) {
-                      pm.addPass(gpu_runtime::createEnumerateEventsPass());
-                    });
-
-static mlir::PassPipelineRegistration<>
     GpuToLlvm("convert-gpu-to-llvm",
               "Converts Gpu runtime dialect to llvm runtime calls",
               [](mlir::OpPassManager &pm) {

--- a/numba_mlir/numba_mlir/mlir/gpu_runtime.py
+++ b/numba_mlir/numba_mlir/mlir/gpu_runtime.py
@@ -48,6 +48,7 @@ if IS_GPU_RUNTIME_AVAILABLE:
             "gpuxStreamDestroy",
             "gpuxSuggestBlockSize",
             "gpuxWait",
+            "gpuxDestroyEvent",
             mlir_func_name("get_global_id"),
             mlir_func_name("get_global_size"),
             mlir_func_name("get_group_id"),

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -2294,7 +2294,6 @@ static void populateLowerToGPUPipelineMed(mlir::OpPassManager &pm) {
   pm.addPass(std::make_unique<OutlineInitPass>());
   pm.addNestedPass<mlir::func::FuncOp>(
       std::make_unique<GenerateOutlineContextPass>());
-  pm.addPass(gpu_runtime::createEnumerateEventsPass());
   commonOptPasses(pm);
 }
 static void populateLowerToGPUPipelineLow(mlir::OpPassManager &pm) {


### PR DESCRIPTION
Get rid of `EnumerateEventsPass` and allocate events dynamically instead.