### PR TITLE
Fix gpu tests on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -303,6 +303,16 @@ jobs:
           conda activate test-env
           python "$env:GITHUB_WORKSPACE/scripts/run_package_tests.py" verbose
 
+      - name: Run offload tests
+        run: |
+          cd numba_mlir
+          conda activate test-env
+          conda install greenlet dpctl -c intel -c conda-forge
+          conda list
+          $env:NUMBA_MLIR_GPU_RUNTIME="sycl"
+          $env:NUMBA_MLIR_DEFAULT_DEVICE="opencl:cpu:0"
+          python "$env:GITHUB_WORKSPACE/scripts/run_package_tests.py" verbose gpu
+
       - name: Build wheels
         run: |
           mkdir numba_mlir_wheels

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -304,6 +304,7 @@ jobs:
           python "$env:GITHUB_WORKSPACE/scripts/run_package_tests.py" verbose
 
       - name: Run offload tests
+        if: false # Doesn't work
         run: |
           cd numba_mlir
           conda activate test-env

--- a/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
@@ -1563,7 +1563,7 @@ def test_cfd_use_64bit_index_prange_default():
     jit_func_defualt = njit(py_func)
     jit_func_64 = njit(py_func, gpu_use_64bit_index=True)
 
-    a = np.zeros((2, 3), dtype=int)
+    a = np.zeros((2, 3), dtype=np.float32)
 
     da_default = _from_host(a, buffer="device")
     da64 = _from_host(a, buffer="device")
@@ -1600,7 +1600,7 @@ def test_cfd_use_64bit_index_prange():
     jit_func64 = njit(py_func, gpu_use_64bit_index=True)
     jit_func32 = njit(py_func, gpu_use_64bit_index=False)
 
-    a = np.zeros((6, 8), dtype=int)
+    a = np.zeros((6, 8), dtype=np.float32)
 
     da64 = _from_host(a, buffer="device")
     da32 = _from_host(a, buffer="device")
@@ -1638,7 +1638,7 @@ def test_cfd_use_64bit_index_kernel():
     jit_kern64 = kernel_cached(py_func, gpu_use_64bit_index=True)
     jit_kern32 = kernel_cached(py_func, gpu_use_64bit_index=False)
 
-    a = np.zeros((6, 8), dtype=int)
+    a = np.zeros((6, 8), dtype=np.float32)
 
     da64 = _from_host(a, buffer="device")
     da32 = _from_host(a, buffer="device")


### PR DESCRIPTION
* `dtype=int` transpates to int32 in win