### PR TITLE
Fix NormalizeMemrefArgsPass

### DIFF
--- a/mlir/include/numba/Dialect/numba_util/NumbaUtilOps.td
+++ b/mlir/include/numba/Dialect/numba_util/NumbaUtilOps.td
@@ -145,6 +145,8 @@ def RetainOp : NumbaUtil_Op<"retain", [ViewLikeOpInterface]> {
   let extraClassDeclaration = [{
       ::mlir::Value getViewSource() { return getSource(); }
   }];
+
+  let hasCanonicalizer = 1;
 }
 
 def ChangeLayoutOp : NumbaUtil_Op<"change_layout", [

--- a/mlir/lib/Transforms/MemoryRewrites.cpp
+++ b/mlir/lib/Transforms/MemoryRewrites.cpp
@@ -374,6 +374,7 @@ mergeMemrefTypes(mlir::MemRefType type1, mlir::MemRefType type2, bool isDst) {
 
   assert(type1.getRank() == type2.getRank());
   llvm::SmallVector<int64_t> shape;
+  shape.reserve(type1.getRank());
   for (auto &&[dim1, dim2] : llvm::zip(type1.getShape(), type2.getShape()))
     shape.emplace_back(mergeDims(dim1, dim2, isDst));
 
@@ -450,7 +451,7 @@ struct NormalizeMemrefArgs
           if (auto cast = arg.getDefiningOp<mlir::memref::CastOp>())
             arg = cast.getSource();
 
-          auto type = arg.getType().cast<mlir::MemRefType>();
+          auto type = mlir::cast<mlir::MemRefType>(arg.getType());
           if (!newType) {
             newType = type;
             continue;
@@ -461,10 +462,11 @@ struct NormalizeMemrefArgs
             newType = nullptr;
             break;
           }
+          newType = *result;
         }
         if (newType) {
-          if (auto result =
-                  mergeMemrefTypes(newType, arg.cast<mlir::MemRefType>(), true))
+          if (auto result = mergeMemrefTypes(
+                  newType, mlir::cast<mlir::MemRefType>(arg), true))
             newType = *result;
         }
 

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
@@ -1911,6 +1911,27 @@ def test_tensor_if(a, b):
     assert_equal(py_func(a, b), jit_func(a, b))
 
 
+def test_static_dim_call():
+    def py_func1(a):
+        return a.shape[0]
+
+    jit_func1 = njit(py_func1)
+
+    def py_func2(a, b):
+        return py_func1(a), py_func1(b)
+
+    def py_func3(a, b):
+        return jit_func1(a), jit_func1(b)
+
+    jit_func3 = njit(py_func3)
+
+    a = np.empty(1)
+    b = np.empty(10)
+
+    assert_equal(py_func2(a, b), jit_func3(a, b))
+    # assert_equal(py_func3(a, b), jit_func3(a, b)) TODO: caching issue
+
+
 def _cov(m, y=None, rowvar=True, bias=False, ddof=None):
     return np.cov(m, y, rowvar, bias, ddof)
 


### PR DESCRIPTION
* Memref type wasn't properly updated in `NormalizeMemrefArgs`
* Add additional canonicalization to `RetainOp`
* There is still issue with func caching (see commented test), but it will be fixed separately