### PR TITLE
Some mixed generics alias analysis

### DIFF
--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
@@ -1829,7 +1829,7 @@ def test_alias2():
     assert_equal(py_func(4), jit_func(4))
 
 
-def test_inplace_alias():
+def test_inplace_alias1():
     def py_func(a):
         a += 1
         a[:] = 3
@@ -1842,6 +1842,22 @@ def test_inplace_alias():
     jit_arg = a.copy()
     py_func(py_arg)
     jit_func(jit_arg)
+    assert_equal(py_arg, jit_arg)
+
+
+def test_inplace_alias2():
+    def py_func(a, b):
+        a[:] += b
+
+    jit_func = njit(py_func)
+
+    a = np.ones(1)
+    b = a + 2
+
+    py_arg = a.copy()
+    jit_arg = a.copy()
+    py_func(py_arg, b)
+    jit_func(jit_arg, b)
     assert_equal(py_arg, jit_arg)
 
 

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -2863,7 +2863,13 @@ struct LinalgOptInnerPass
   void runOnOperation() override;
 };
 
-static bool defaultControlFusionFn(mlir::OpOperand * /*fusedOperand*/) {
+static bool defaultControlFusionFn(mlir::OpOperand *fusedOperand) {
+  if (auto generic =
+          mlir::dyn_cast<mlir::linalg::GenericOp>(fusedOperand->getOwner())) {
+    // TODO: Need better analysis for mixed generics
+    if (!generic.hasTensorSemantics() && !generic.hasBufferSemantics())
+      return false;
+  }
   return true;
 }
 

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -2924,9 +2924,9 @@ static bool mayAliasImpl(mlir::Value src, F &&mayAliasCheck) {
     if (mayAliasCheck(current))
       return true;
 
-    if (auto extract = current.getDefiningOp<mlir::tensor::ExtractSliceOp>()) {
+    if (auto extract = current.getDefiningOp<mlir::tensor::ExtractSliceOp>())
       worklist.emplace_back(extract.getSource());
-    }
+
     if (auto generic = current.getDefiningOp<mlir::linalg::GenericOp>()) {
       for (auto arg : generic->getOperands()) {
         if (mlir::isa<mlir::MemRefType>(arg.getType()) && mayAliasCheck(arg))
@@ -2935,14 +2935,14 @@ static bool mayAliasImpl(mlir::Value src, F &&mayAliasCheck) {
         worklist.emplace_back(arg);
       }
     }
+
     if (auto toTensor =
-            current.getDefiningOp<mlir::bufferization::ToTensorOp>()) {
+            current.getDefiningOp<mlir::bufferization::ToTensorOp>())
       worklist.emplace_back(toTensor.getMemref());
-    }
+
     if (auto enforceShape =
-            current.getDefiningOp<numba::util::EnforceShapeOp>()) {
+            current.getDefiningOp<numba::util::EnforceShapeOp>())
       worklist.emplace_back(enforceShape.getValue());
-    }
 
   } while (!worklist.empty());
   return false;


### PR DESCRIPTION
* Very primitive and conservative for now
* Avoid fusion with mixed `linalg.generic` if it can potentially result data race between reading and writing to same input/output
* Expanded `MixedGenericsAliasAnalysis` pass from previous PR
