### PR TITLE
switch `MakeBarriersUniformPass` to `ub.poison`

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -156,6 +156,8 @@ target_link_libraries(${MLIR_EXTENSIONS_LIB} PRIVATE
     MLIRMathToSPIRV
     MLIRTensorTransforms
     MLIRTransforms
+    MLIRUBDialect
+    MLIRUBToSPIRV
     )
 
 target_include_directories(${MLIR_EXTENSIONS_LIB} SYSTEM PRIVATE

--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -18,6 +18,7 @@
 #include <mlir/Conversion/MathToSPIRV/MathToSPIRV.h>
 #include <mlir/Conversion/MemRefToSPIRV/MemRefToSPIRV.h>
 #include <mlir/Conversion/SCFToSPIRV/SCFToSPIRV.h>
+#include <mlir/Conversion/UBToSPIRV/UBToSPIRV.h>
 #include <mlir/Dialect/Affine/IR/AffineOps.h>
 #include <mlir/Dialect/Bufferization/Transforms/BufferViewFlowAnalysis.h>
 #include <mlir/Dialect/ControlFlow/IR/ControlFlowOps.h>
@@ -1079,6 +1080,7 @@ struct GPUToSpirvPass
       mlir::arith::populateArithToSPIRVPatterns(typeConverter, patterns);
       mlir::populateMathToSPIRVPatterns(typeConverter, patterns);
       mlir::populateMemRefToSPIRVPatterns(typeConverter, patterns);
+      mlir::ub::populateUBToSPIRVConversionPatterns(typeConverter, patterns);
 
       patterns.insert<
           ConvertBitcastOp<numba::util::BitcastOp>,

--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -34,6 +34,7 @@
 #include <mlir/Dialect/SPIRV/IR/SPIRVOps.h>
 #include <mlir/Dialect/SPIRV/IR/TargetAndABI.h>
 #include <mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h>
+#include <mlir/Dialect/UB/IR/UBOps.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Target/SPIRV/Serialization.h>
 #include <mlir/Transforms/DialectConversion.h>
@@ -935,6 +936,27 @@ public:
   }
 };
 
+class ConvertPoison : public mlir::OpConversionPattern<mlir::ub::PoisonOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::ub::PoisonOp op, mlir::ub::PoisonOp::Adaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto srcType = op.getType();
+    if (!mlir::isa<mlir::MemRefType>(srcType))
+      return mlir::failure();
+
+    auto converter = getTypeConverter();
+    auto type = converter->convertType(srcType);
+    if (!type)
+      return mlir::failure();
+
+    rewriter.replaceOpWithNewOp<mlir::spirv::UndefOp>(op, type);
+    return mlir::success();
+  }
+};
+
 template <typename SourceOp, mlir::spirv::BuiltIn builtin>
 class LaunchConfigConversion : public mlir::OpConversionPattern<SourceOp> {
 public:
@@ -1086,7 +1108,8 @@ struct GPUToSpirvPass
           ConvertBitcastOp<numba::util::BitcastOp>,
           ConvertBitcastOp<numba::util::MemrefBitcastOp>, ConvertAtomicRMW,
           AllocaOpPattern, ConvertFunc, ConvertAssert, ConvertBarrierOp,
-          ConvertMemFenceOp, ConvertUndef, ConvertGlobalOp, ConvertGetGlobalOp,
+          ConvertMemFenceOp, ConvertUndef, ConvertPoison, ConvertGlobalOp,
+          ConvertGetGlobalOp,
           LaunchConfigConversion<mlir::gpu::BlockIdOp,
                                  mlir::spirv::BuiltIn::WorkgroupId>,
           LaunchConfigConversion<mlir::gpu::GridDimOp,

--- a/mlir/lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
+++ b/mlir/lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
@@ -4,12 +4,12 @@
 
 #include "numba/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.hpp"
 
-#include "numba/Dialect/numba_util/Dialect.hpp"
-
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/GPU/IR/GPUDialect.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/Dialect/UB/IR/UBOps.h>
 #include <mlir/IR/Dominance.h>
+#include <mlir/IR/IRMapping.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
 
@@ -148,7 +148,8 @@ static mlir::LogicalResult convertBlockingOp(mlir::Operation *op,
     llvm::SmallVector<mlir::Value> results;
     results.reserve(yieldArgs.size());
     for (auto arg : yieldArgs) {
-      auto val = builder.create<numba::util::UndefOp>(loc, arg.getType());
+      auto val =
+          builder.create<mlir::ub::PoisonOp>(loc, arg.getType(), nullptr);
       results.emplace_back(val);
     }
 
@@ -283,7 +284,7 @@ struct MakeBarriersUniformPass
     registry.insert<mlir::arith::ArithDialect>();
     registry.insert<mlir::gpu::GPUDialect>();
     registry.insert<mlir::scf::SCFDialect>();
-    registry.insert<numba::util::NumbaUtilDialect>();
+    registry.insert<mlir::ub::UBDialect>();
   }
 
   void runOnOperation() override {

--- a/mlir/test/Transforms/make-barriers-uniform.mlir
+++ b/mlir/test/Transforms/make-barriers-uniform.mlir
@@ -18,6 +18,7 @@ func.func @test() {
 }
 
 // CHECK-LABEL: func @test
+//       CHECK: %[[V2:.*]] = ub.poison : i32
 //       CHECK: gpu.launch blocks
 //       CHECK: %[[COND:.*]] = "test.test1"() : () -> i1
 //       CHECK: %[[RES1:.*]] = scf.if %[[COND]] -> (i32) {
@@ -25,7 +26,6 @@ func.func @test() {
 //       CHECK: %[[V1:.*]] = "test.test3"() : () -> i32
 //       CHECK: scf.yield %[[V1]] : i32
 //       CHECK: } else {
-//       CHECK: %[[V2:.*]] = numba_util.undef : i32
 //       CHECK: scf.yield %[[V2]] : i32
 //       CHECK: }
 //       CHECK: gpu.barrier {test.test_attr}
@@ -62,6 +62,9 @@ func.func @test() {
 }
 
 // CHECK-LABEL: func @test
+//       CHECK: %[[V6:.*]] = ub.poison : index
+//       CHECK: %[[V4:.*]] = ub.poison : i64
+//       CHECK: %[[V3:.*]] = ub.poison : i32
 //       CHECK: gpu.launch blocks
 //       CHECK: %[[COND:.*]] = "test.test1"() : () -> i1
 //       CHECK: %[[RES1:.*]]:2 = scf.if %[[COND]] -> (i32, i64) {
@@ -70,8 +73,6 @@ func.func @test() {
 //       CHECK: %[[V2:.*]] = "test.test4"() : () -> i64
 //       CHECK: scf.yield %[[V1]], %[[V2]] : i32, i64
 //       CHECK: } else {
-//       CHECK: %[[V3:.*]] = numba_util.undef : i32
-//       CHECK: %[[V4:.*]] = numba_util.undef : i64
 //       CHECK: scf.yield %[[V3]], %[[V4]] : i32, i64
 //       CHECK: }
 //       CHECK: gpu.barrier
@@ -81,7 +82,6 @@ func.func @test() {
 //       CHECK: %[[V5:.*]] = "test.test7"() : () -> index
 //       CHECK: scf.yield %[[V5]] : index
 //       CHECK: } else {
-//       CHECK: %[[V6:.*]] = numba_util.undef : index
 //       CHECK: scf.yield %[[V6]] : index
 //       CHECK: }
 //       CHECK: gpu.barrier {test.test_attr}
@@ -119,6 +119,8 @@ func.func @test() {
 }
 
 // CHECK-LABEL: func @test
+//       CHECK: %[[V4:.*]] = ub.poison : i64
+//       CHECK: %[[V3:.*]] = ub.poison : i32
 //       CHECK: %[[NEUTRAL:.*]] = arith.constant 0 : i64
 //       CHECK: gpu.launch blocks
 //       CHECK: %[[COND:.*]] = "test.test1"() : () -> i1
@@ -128,8 +130,6 @@ func.func @test() {
 //       CHECK: %[[V2:.*]] = "test.test4"() : () -> i64
 //       CHECK: scf.yield %[[V1]], %[[V2]] : i32, i64
 //       CHECK: } else {
-//       CHECK: %[[V3:.*]] = numba_util.undef : i32
-//       CHECK: %[[V4:.*]] = numba_util.undef : i64
 //       CHECK: scf.yield %[[V3]], %[[V4]] : i32, i64
 //       CHECK: }
 //       CHECK: %[[RARG:.*]] = arith.select %[[COND]], %[[RES1]]#1, %[[NEUTRAL]] : i64
@@ -168,6 +168,8 @@ func.func @test() {
 }
 
 // CHECK-LABEL: func @test
+//       CHECK: %[[V4:.*]] = ub.poison : i64
+//       CHECK: %[[V3:.*]] = ub.poison : i32
 //       CHECK: %[[NEUTRAL:.*]] = arith.constant 1 : i64
 //       CHECK: gpu.launch blocks
 //       CHECK: %[[COND:.*]] = "test.test1"() : () -> i1
@@ -177,8 +179,6 @@ func.func @test() {
 //       CHECK: %[[V2:.*]] = "test.test4"() : () -> i64
 //       CHECK: scf.yield %[[V1]], %[[V2]] : i32, i64
 //       CHECK: } else {
-//       CHECK: %[[V3:.*]] = numba_util.undef : i32
-//       CHECK: %[[V4:.*]] = numba_util.undef : i64
 //       CHECK: scf.yield %[[V3]], %[[V4]] : i32, i64
 //       CHECK: }
 //       CHECK: %[[RARG:.*]] = arith.select %[[COND]], %[[RES1]]#1, %[[NEUTRAL]] : i64
@@ -214,6 +214,8 @@ func.func @test() {
 }
 
 // CHECK-LABEL: func @test
+//       CHECK: %[[V4:.*]] = ub.poison : i64
+//       CHECK: %[[V3:.*]] = ub.poison : i32
 //       CHECK: %[[NEUTRAL:.*]] = arith.constant 9223372036854775807 : i64
 //       CHECK: gpu.launch blocks
 //       CHECK: %[[COND:.*]] = "test.test1"() : () -> i1
@@ -223,8 +225,6 @@ func.func @test() {
 //       CHECK: %[[V2:.*]] = "test.test4"() : () -> i64
 //       CHECK: scf.yield %[[V1]], %[[V2]] : i32, i64
 //       CHECK: } else {
-//       CHECK: %[[V3:.*]] = numba_util.undef : i32
-//       CHECK: %[[V4:.*]] = numba_util.undef : i64
 //       CHECK: scf.yield %[[V3]], %[[V4]] : i32, i64
 //       CHECK: }
 //       CHECK: %[[RARG:.*]] = arith.select %[[COND]], %[[RES1]]#1, %[[NEUTRAL]] : i64
@@ -260,6 +260,7 @@ func.func @test() {
 }
 
 // CHECK-LABEL: func @test
+//       CHECK: %[[V2:.*]] = ub.poison : i32
 //       CHECK: gpu.launch blocks
 //       CHECK: %[[COND:.*]] = "test.test1"() : () -> i1
 //       CHECK: %[[RES1:.*]] = scf.if %[[COND]] -> (i32) {
@@ -267,7 +268,6 @@ func.func @test() {
 //       CHECK: %[[V1:.*]] = "test.test3"() : () -> i32
 //       CHECK: scf.yield %[[V1]] : i32
 //       CHECK: } else {
-//       CHECK: %[[V2:.*]] = numba_util.undef : i32
 //       CHECK: scf.yield %[[V2]] : i32
 //       CHECK: }
 //       CHECK: gpu.barrier

--- a/numba_mlir/numba_mlir/mlir_compiler/CMakeLists.txt
+++ b/numba_mlir/numba_mlir/mlir_compiler/CMakeLists.txt
@@ -103,6 +103,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     MLIRSPIRVTransforms
     MLIRTensorTransforms
     MLIRTransforms
+    MLIRUBToLLVM
     )
 
 target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -24,6 +24,7 @@
 #include <mlir/Dialect/SPIRV/IR/SPIRVOps.h>
 #include <mlir/Dialect/SPIRV/IR/TargetAndABI.h>
 #include <mlir/Dialect/SPIRV/Transforms/Passes.h>
+#include <mlir/Dialect/UB/IR/UBOps.h>
 #include <mlir/IR/Dominance.h>
 #include <mlir/IR/IRMapping.h>
 #include <mlir/Pass/PassManager.h>
@@ -1879,8 +1880,8 @@ public:
             auto isSinkingBeneficiary = [](mlir::Operation *op) -> bool {
               return isa<arith::ConstantOp, func::ConstantOp, arith::SelectOp,
                          arith::CmpIOp, arith::IndexCastOp, arith::MulIOp,
-                         arith::SubIOp, arith::AddIOp, numba::util::UndefOp>(
-                  op);
+                         arith::SubIOp, arith::AddIOp, numba::util::UndefOp,
+                         mlir::ub::PoisonOp>(op);
             };
 
             // Pull in instructions that can be sunk


### PR DESCRIPTION
* Upstream now have `ub.poison`, so we can phase out our custom `numba_util.undef`
* Update pass and tests
* Add `ub.poison` support to `GpuLaunchSinkOpsPass`
* Add poison memref lowering to llvm and SPIR-V (TODO: upstream)