### PR TITLE
Parfor nodes lowering

### DIFF
--- a/numba_mlir/numba_mlir/decorators.py
+++ b/numba_mlir/numba_mlir/decorators.py
@@ -52,7 +52,6 @@ def mlir_jit(
     options.pop("gpu_use_64bit_index", None)
 
     if options.get("replace_parfors", False):
-        assert False, "replace_parfors is not implemented yet"
         pipeline = mlir_compiler_replace_parfors_pipeline
     elif options.get("enable_gpu_pipeline", True):
         pipeline = get_gpu_pipeline(fp64_truncate, use_64bit_index)

--- a/numba_mlir/numba_mlir/mlir/passes.py
+++ b/numba_mlir/numba_mlir/mlir/passes.py
@@ -395,9 +395,8 @@ class MlirReplaceParfors(MlirBackendBase):
 
         return types.Tuple(ret)
 
-
     def _lower_parfor(self, func_ptr, lowerer, parfor):
-        print('-=-=-=-=-=-=- lowerer')
+        print("-=-=-=-=-=-=- lowerer")
         print(lowerer)
 
         context = lowerer.context
@@ -419,7 +418,7 @@ class MlirReplaceParfors(MlirBackendBase):
         args.append(nullptr)
 
         def get_arg(v):
-            return self._repack_arg(builder, typemap[v], lowerer.loadvar(v));
+            return self._repack_arg(builder, typemap[v], lowerer.loadvar(v))
 
         args += self._enumerate_parfor_args(parfor, get_arg)
 
@@ -450,7 +449,6 @@ class MlirReplaceParfors(MlirBackendBase):
         for red_val, red_var in zip(red_vals, parfor.redvars):
             lowerer.storevar(red_val, name=red_var)
 
-
     def _repack_arg(self, builder, orig_type, arg):
         ret = []
         typ = arg.type
@@ -461,4 +459,3 @@ class MlirReplaceParfors(MlirBackendBase):
             ret.append(arg)
 
         return ret
-

--- a/numba_mlir/numba_mlir/mlir/passes.py
+++ b/numba_mlir/numba_mlir/mlir/passes.py
@@ -463,12 +463,13 @@ class MlirReplaceParfors(MlirBackendBase):
         if isinstance(typ, llvmlite.ir.BaseStructType):
             usmarray_type = self._usmarray_type
             is_usm_array = usmarray_type and isinstance(orig_type, usmarray_type)
+            print('asdsadasdsasdsa', is_usm_array)
             # USM array data model mostly follows numpy model except additional
             # sycl queue pointer. Queue can be extracted from meminfo, so just
             # skip it.
             # TODO: Actually parse data models instead of hardcoding index?
             for i in range(len(typ)):
-                if i == 5:
+                if is_usm_array and i == 5:
                     continue
 
                 ret.append(builder.extract_value(arg, i))

--- a/numba_mlir/numba_mlir/mlir/tests/test_basic.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_basic.py
@@ -976,18 +976,37 @@ def test_named_args_indirect():
     assert_equal(py_func2(a, b, c, d), jit_func2(a, b, c, d))
 
 
-@pytest.mark.xfail(reason="replace_parfors is not implemented yet")
 def test_replace_parfor():
+    import numpy as np
+
     def py_func(c):
         res = 0
         for i in numba.prange(len(c)):
-            ind = 2 if i == 4 else i
-            res = res + c[ind]
+            # ind = 2 if i == 4 else i
+            # res = res + c[ind]
+            res = res + c[i]
         return res
 
-    import numpy as np
-
     a = np.arange(10)
+
+    jit_func = njit(py_func, parallel=True, replace_parfors=True)
+    assert_equal(py_func(a), jit_func(a))
+
+
+@pytest.mark.skip(reason="for debugging purposes only!")
+def test_replace_parfor_dpnp():
+    import numba_dpex
+    import dpnp
+
+    def py_func(c):
+        res = 0
+        for i in numba.prange(len(c)):
+            # ind = 2 if i == 4 else i
+            # res = res + c[ind]
+            res = res + c[i]
+        return res
+
+    a = dpnp.arange(10)
 
     jit_func = njit(py_func, parallel=True, replace_parfors=True)
     assert_equal(py_func(a), jit_func(a))

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -1316,7 +1316,6 @@ py::capsule lowerParfor(const pybind11::object &compilationContext,
   auto &module = mod->module;
   auto func = PlierLowerer(context, mod->typeConverter)
                   .lowerParfor(compilationContext, module, parforInst);
-  func->dump();
   return py::capsule(func.getOperation()); // no dtor, func owned by the module.
 }
 


### PR DESCRIPTION
Add a proper parfor lowering by adding call inst to previously generated native func. Add proper args and results repacking, including `USMNdArray` type support.
