### PR TITLE
Slice type support as function argument

### DIFF
--- a/mlir/test/Dialect/ntensor/ntensor-to-memref.mlir
+++ b/mlir/test/Dialect/ntensor/ntensor-to-memref.mlir
@@ -289,3 +289,21 @@ func.func @test(%arg1: !ntensor.ntensor<?xf32>) -> !ntensor.ntensor<5xf32> {
 //  CHECK-NEXT:   numba_util.env_region_yield %[[RES1]] : memref<5xf32>
 //  CHECK-NEXT:   }
 //  CHECK-NEXT:   return %[[RES]] : memref<5xf32>
+
+// -----
+
+func.func @test(%arg1: index, %arg2: !ntensor.slice) -> (index, index, index, index) {
+  %0:4 = ntensor.resolve_slice %arg2, %arg1
+  return %0#0, %0#1, %0#2, %0#3 : index, index, index, index
+}
+// CHECK-LABEL: func @test
+//  CHECK-SAME:   (%[[ARG1:.*]]: index, %[[ARG2:.*]]: tuple<index, index, index>)
+//       CHECK:   %[[C0:.*]] = arith.constant 0 : index
+//       CHECK:   %[[C1:.*]] = arith.constant 1 : index
+//       CHECK:   %[[C2:.*]] = arith.constant 2 : index
+//       CHECK:   %[[BEGIN:.*]] = numba_util.tuple_extract %[[ARG2]] : tuple<index, index, index>, %[[C0]] -> index
+//       CHECK:   %[[END:.*]] = numba_util.tuple_extract %[[ARG2]] : tuple<index, index, index>, %[[C1]] -> index
+//       CHECK:   %[[STEP:.*]] = numba_util.tuple_extract %[[ARG2]] : tuple<index, index, index>, %[[C2]] -> index
+//       CHECK:   %[[SLICE:.*]] = ntensor.build_slice(%[[BEGIN]] : %[[END]] : %[[STEP]])
+//       CHECK:   %[[BEGIN1:.*]], %[[END1:.*]], %[[STEP1:.*]] = ntensor.resolve_slice %[[SLICE]], %[[ARG1]]
+//       CHECK:   return %[[BEGIN1]], %[[END1]], %[[STEP1]] : index, index, index

--- a/numba_mlir/numba_mlir/mlir/passes.py
+++ b/numba_mlir/numba_mlir/mlir/passes.py
@@ -383,13 +383,15 @@ class MlirReplaceParfors(MlirBackendBase):
 
     def _get_parfor_params(self, parfor):
         params = []
-        init_block_vars = set()
-        for instr in parfor.init_block.body:
-            if hasattr(instr, "target"):
-                init_block_vars.add(instr.target.name)
+        usedefs = numba.core.analysis.compute_use_defs({0: parfor.init_block})
+
+        init_block_uses = usedefs.usemap[0]
+        init_block_defs = usedefs.defmap[0]
+
+        params += sorted(list(init_block_uses))
 
         for param in parfor.params:
-            if param in init_block_vars:
+            if param in init_block_defs:
                 continue
 
             params.append(param)

--- a/numba_mlir/numba_mlir/mlir/tests/test_numba_parfor.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numba_parfor.py
@@ -353,6 +353,20 @@ def test_replace_parfor_numpy_operator():
         assert len(ir) > 0  # Check some code was actually generated
 
 
+def test_replace_parfor_slice_capture():
+    def py_func(a):
+        a += 1
+        a[:] = 3
+
+    a = np.ones(1)
+
+    jit_func = njit(py_func, parallel=True, replace_parfors=True)
+    with print_pass_ir([], ["CFGToSCFPass"]):
+        assert_equal(py_func(a), jit_func(a))
+        ir = get_print_buffer()
+        assert len(ir) > 0  # Check some code was actually generated
+
+
 def test_replace_parfor_prange():
     def py_func(c):
         for i in numba.prange(len(c)):

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
@@ -1791,6 +1791,16 @@ def test_slice3(count):
     assert_equal(py_func(arr.copy()[::2]), jit_func(arr.copy()[::2]))
 
 
+@pytest.mark.parametrize("s", [slice(1), slice(2, 3), slice(3, 4, 2)])
+def test_slice_arg(s):
+    def py_func(a, s):
+        return a[s]
+
+    jit_func = njit(py_func)
+    arr = np.arange(10)
+    assert_equal(py_func(arr, s), jit_func(arr, s))
+
+
 def test_multidim_slice():
     def py_func(a, b):
         return a[1, b, :]

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -53,6 +53,7 @@
 #include "numba/Transforms/CastUtils.hpp"
 #include "numba/Transforms/CommonOpts.hpp"
 #include "numba/Transforms/CompositePass.hpp"
+#include "numba/Transforms/ExpandTuple.hpp"
 #include "numba/Transforms/FuncTransforms.hpp"
 #include "numba/Transforms/InlineUtils.hpp"
 #include "numba/Transforms/LoopUtils.hpp"
@@ -3585,6 +3586,7 @@ static void populatePlierToLinalgOptPipeline(mlir::OpPassManager &pm) {
       }));
 
   pm.addPass(numba::createNtensorToMemrefPass());
+  pm.addPass(numba::createExpandTuplePass());
   pm.addPass(mlir::createCanonicalizerPass());
 
   pm.addPass(numba::createMakeSignlessPass());


### PR DESCRIPTION
* Parfor nodes sometimes capture slices into init block
* Add a a proper lowering when `builde_slice`->`resolve_slice` ops cannot be folded.
