### PR TITLE
Lazy register FixedArray type

### DIFF
--- a/numba_mlir/numba_mlir/mlir/compiler.py
+++ b/numba_mlir/numba_mlir/mlir/compiler.py
@@ -7,6 +7,7 @@ Define compiler pipelines.
 """
 
 from .lowering import mlir_NativeLowering
+from .array_type import ensure_types_resgistered
 
 import functools
 
@@ -122,6 +123,7 @@ class mlir_PassBuilder(orig_DefaultPassBuilder):
 
 class mlir_compiler_pipeline(orig_CompilerBase):
     def define_pipelines(self):
+        ensure_types_resgistered()
         # this maintains the objmode fallback behaviour
         pms = []
         if not self.state.flags.force_pyobject:
@@ -135,6 +137,7 @@ class mlir_compiler_pipeline(orig_CompilerBase):
 def get_gpu_pipeline(fp64_truncate, use_64bit_index):
     class mlir_compiler_gpu_pipeline(orig_CompilerBase):
         def define_pipelines(self):
+            ensure_types_resgistered()
             # this maintains the objmode fallback behaviour
             pms = []
             if not self.state.flags.force_pyobject:


### PR DESCRIPTION
Registering this type makes vanilla numba 2x slower for some reason. Register type lazily, only if user actually calls our decorated function.

TODO: refactor to targets and don't use global registry, or, better, just drop numba type inference entirely.
