### PR TITLE
Parallel region refactoring

### DIFF
--- a/mlir/include/numba/Dialect/numba_util/Dialect.hpp
+++ b/mlir/include/numba/Dialect/numba_util/Dialect.hpp
@@ -31,7 +31,6 @@ namespace util {
 namespace attributes {
 llvm::StringRef getFastmathName();
 llvm::StringRef getJumpMarkersName();
-llvm::StringRef getParallelName();
 llvm::StringRef getMaxConcurrencyName();
 llvm::StringRef getForceInlineName();
 llvm::StringRef getOptLevelName();

--- a/mlir/include/numba/Dialect/numba_util/NumbaUtilOps.td
+++ b/mlir/include/numba/Dialect/numba_util/NumbaUtilOps.td
@@ -67,6 +67,8 @@ def IndexRangeAttr
   let assemblyFormat = "`<` `[` $min `,` $max `]` `>`";
 }
 
+def ParallelAttr : NumbaUtil_Attr<"Parallel", "parallel">;
+
 def EnforceShapeOp : NumbaUtil_Op<"enforce_shape", [Pure]> {
 
   let arguments = (ins AnyShaped:$value, Variadic<Index>:$sizes);

--- a/mlir/include/numba/Transforms/LoopUtils.hpp
+++ b/mlir/include/numba/Transforms/LoopUtils.hpp
@@ -8,13 +8,14 @@
 #include <llvm/ADT/SmallVector.h>
 
 namespace mlir {
-struct LogicalResult;
-class PatternRewriter;
-class Value;
 class Location;
 class OpBuilder;
-class Type;
+class Operation;
+class PatternRewriter;
 class Region;
+class Type;
+class Value;
+struct LogicalResult;
 namespace scf {
 class ForOp;
 class WhileOp;
@@ -46,5 +47,7 @@ mlir::LogicalResult lowerWhileToFor(
     llvm::function_ref<void(mlir::scf::ForOp)> results = nullptr);
 
 mlir::LogicalResult naivelyFuseParallelOps(mlir::Region &region);
-mlir::LogicalResult prepareForFusion(mlir::Region &region);
+mlir::LogicalResult
+prepareForFusion(mlir::Region &region,
+                 llvm::function_ref<bool(mlir::Operation &)> needPrepare);
 } // namespace numba

--- a/mlir/lib/Dialect/numba_util/Dialect.cpp
+++ b/mlir/lib/Dialect/numba_util/Dialect.cpp
@@ -48,10 +48,6 @@ llvm::StringRef numba::util::attributes::getJumpMarkersName() {
   return "numba.pipeline_jump_markers";
 }
 
-llvm::StringRef numba::util::attributes::getParallelName() {
-  return "numba.parallel";
-}
-
 llvm::StringRef numba::util::attributes::getMaxConcurrencyName() {
   return "numba.max_concurrency";
 }

--- a/mlir/lib/Transforms/LoopUtils.cpp
+++ b/mlir/lib/Transforms/LoopUtils.cpp
@@ -5,10 +5,8 @@
 #include "numba/Transforms/LoopUtils.hpp"
 
 #include "numba/Analysis/AliasAnalysis.hpp"
-#include "numba/Dialect/numba_util/Dialect.hpp"
 #include "numba/Dialect/plier/Dialect.hpp"
 #include "numba/Transforms/CastUtils.hpp"
-#include "numba/Transforms/ConstUtils.hpp"
 
 #include <llvm/ADT/SmallVector.h>
 
@@ -539,16 +537,17 @@ mlir::LogicalResult numba::naivelyFuseParallelOps(Region &region) {
   return mlir::success(changed);
 }
 
-LogicalResult numba::prepareForFusion(Region &region) {
+LogicalResult numba::prepareForFusion(
+    Region &region, llvm::function_ref<bool(mlir::Operation &)> needPrepare) {
   DominanceInfo dom(region.getParentOp());
   bool changed = false;
   for (auto &block : region) {
     for (auto &parallelOp : llvm::make_early_inc_range(block)) {
       for (auto &innerReg : parallelOp.getRegions())
-        if (succeeded(prepareForFusion(innerReg)))
+        if (succeeded(prepareForFusion(innerReg, needPrepare)))
           changed = true;
 
-      if (!isa<scf::ParallelOp>(parallelOp))
+      if (!needPrepare(parallelOp))
         continue;
 
       auto it = Block::iterator(parallelOp);
@@ -560,7 +559,7 @@ LogicalResult numba::prepareForFusion(Region &region) {
       auto terminate = false;
       while (!terminate) {
         auto &currentOp = *it;
-        if (isa<scf::ParallelOp>(currentOp))
+        if (needPrepare(currentOp))
           break;
 
         if (it == block.begin()) {

--- a/mlir/lib/Transforms/LoopUtils.cpp
+++ b/mlir/lib/Transforms/LoopUtils.cpp
@@ -436,9 +436,6 @@ fuseIfLegal(scf::ParallelOp firstPloop, scf::ParallelOp &secondPloop,
   auto newSecondPloop = b.create<mlir::scf::ParallelOp>(
       secondPloop.getLoc(), secondPloop.getLowerBound(),
       secondPloop.getUpperBound(), secondPloop.getStep(), newInitVars);
-  if (secondPloop->hasAttr(numba::util::attributes::getParallelName()))
-    newSecondPloop->setAttr(numba::util::attributes::getParallelName(),
-                            mlir::UnitAttr::get(b.getContext()));
 
   newSecondPloop.getRegion().getBlocks().splice(
       newSecondPloop.getRegion().begin(), secondPloop.getRegion().getBlocks());

--- a/numba_mlir/numba_mlir/mlir/tests/test_numba_parfor.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numba_parfor.py
@@ -50,7 +50,6 @@ def _gen_tests():
         "test_parfor_race_1",  # cfg->scf conversion failure
         "test_record_array_setitem_yield_array",  # Record and string support
         "test_record_array_setitem",  # Record and string support
-        "test_prange_two_instances_same_reduction_var",  # Non-trivial reduction
         "test_prange_conflicting_reduction_ops",  # Conflicting reduction reduction check
         "test_ssa_false_reduction",  # Frontend: object has no attribute 'name'
         "test_mutable_list_param",  # List support
@@ -108,9 +107,7 @@ def _gen_tests():
         "test_real_imag_attr",
         "test_tuple_arg_not_whole_array",
         "test_tuple_for_pndindex",
-        "test_if_not_else_reduction",
         "test_int_arg_pndindex",
-        "test_non_identity_initial",
         "test_prange_optional",
         "test_1array_control_flow",
     }
@@ -383,9 +380,9 @@ def _gen_replace_parfor_tests():
         "test_min",
         "test_nd_parfor",
         "test_arraymap",
-        "test_prange04",
     }
     skip_tests = {
+        "test_prange04",  # flaky test
         "test_prange22",  # flaky test
         "test_no_warn_if_cache_set",  # caching is not supported
         "test_prange07",  # reverse iteration

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
@@ -775,7 +775,7 @@ def test_prange_lowering():
         arr = np.arange(10000, dtype=np.float32)
         assert_equal(py_func(arr), jit_func(arr))
         ir = get_print_buffer()
-        assert ir.count("numba_util.parallel") == 1, ir
+        assert ir.count('"numba_util.parallel"') == 1, ir
 
 
 @pytest.mark.skip()

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -993,11 +993,7 @@ protected:
       return mlir::failure();
 
     llvm::SmallVector<mlir::scf::ForOp> newOps;
-    auto setAttr = [&](mlir::scf::ForOp op) {
-      auto unitAttr = mlir::UnitAttr::get(op->getContext());
-      op->setAttr(numba::util::attributes::getParallelName(), unitAttr);
-      newOps.emplace_back(op);
-    };
+    auto setAttr = [&](mlir::scf::ForOp op) { newOps.emplace_back(op); };
     if (mlir::failed(numba::lowerRange(op, args, kwargs, rewriter, setAttr)))
       return mlir::failure();
 

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToLlvm.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToLlvm.cpp
@@ -1103,7 +1103,6 @@ public:
 static void copyAttrs(mlir::Operation *src, mlir::Operation *dst) {
   const mlir::StringRef attrs[] = {
       numba::util::attributes::getFastmathName(),
-      numba::util::attributes::getParallelName(),
       numba::util::attributes::getMaxConcurrencyName(),
   };
   for (auto name : attrs)

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -177,12 +177,7 @@ lowerPrange(plier::PyCallOp op, mlir::ValueRange operands,
             llvm::ArrayRef<std::pair<llvm::StringRef, mlir::Value>> kwargs,
             mlir::PatternRewriter &rewriter) {
   auto parent = op->getParentOp();
-  auto setAttr = [](mlir::scf::ForOp op) {
-    op->setAttr(numba::util::attributes::getParallelName(),
-                mlir::UnitAttr::get(op->getContext()));
-  };
-  if (mlir::succeeded(
-          numba::lowerRange(op, operands, kwargs, rewriter, setAttr))) {
+  if (mlir::succeeded(numba::lowerRange(op, operands, kwargs, rewriter))) {
     rerunScfPipeline(parent);
     return mlir::success();
   }

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -3299,7 +3299,11 @@ void PostLinalgOptInnerPass::runOnOperation() {
                   OptimizeIdentityLayoutStrides>(&context);
 
   auto additionalOpt = [](mlir::func::FuncOp op) {
-    (void)numba::prepareForFusion(op.getRegion());
+    auto check = [](mlir::Operation &op) -> bool {
+      return mlir::isa<mlir::scf::ParallelOp, numba::util::EnvironmentRegionOp>(
+          op);
+    };
+    (void)numba::prepareForFusion(op.getRegion(), check);
     return numba::naivelyFuseParallelOps(op.getRegion());
   };
 


### PR DESCRIPTION
* Instead of attaching attributes to loops for prange, wrap them into region, so guaranteed to be preserved during transformations
