### PR TITLE
Gpu alloc refactoring

### DIFF
--- a/mlir/include/numba/Dialect/numba_util/NumbaUtilOps.td
+++ b/mlir/include/numba/Dialect/numba_util/NumbaUtilOps.td
@@ -372,4 +372,9 @@ def StringConstOp : NumbaUtil_Op<"str_constant",
   let hasFolder = 1;
 }
 
+def WrapAllocatedPointer : NumbaUtil_Op<"wrap_allocated_pointer", [Pure]> {
+  let arguments = (ins AnyType:$ptr, SymbolRefAttr:$dtor, AnyType:$dtor_data);
+  let results = (outs AnyType:$result);
+}
+
 #endif // PLIER_UTIL_OPS

--- a/mlir/include/numba/Dialect/numba_util/NumbaUtilOps.td
+++ b/mlir/include/numba/Dialect/numba_util/NumbaUtilOps.td
@@ -13,6 +13,7 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/ViewLikeInterface.td"
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpBase.td"
+include "mlir/IR/SymbolInterfaces.td"
 
 def NumbaUtil_Dialect : Dialect {
   let name = "numba_util";
@@ -372,8 +373,9 @@ def StringConstOp : NumbaUtil_Op<"str_constant",
   let hasFolder = 1;
 }
 
-def WrapAllocatedPointer : NumbaUtil_Op<"wrap_allocated_pointer", [Pure]> {
-  let arguments = (ins AnyType:$ptr, SymbolRefAttr:$dtor, AnyType:$dtor_data);
+def WrapAllocatedPointer : NumbaUtil_Op<"wrap_allocated_pointer",
+    [Pure, DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+  let arguments = (ins AnyType:$ptr, FlatSymbolRefAttr:$dtor, AnyType:$dtor_data);
   let results = (outs AnyType:$result);
 }
 

--- a/mlir/include/numba/Transforms/FuncUtils.hpp
+++ b/mlir/include/numba/Transforms/FuncUtils.hpp
@@ -20,7 +20,8 @@ class FuncOp;
 
 namespace llvm {
 class StringRef;
-}
+class Twine;
+} // namespace llvm
 
 namespace numba {
 mlir::func::FuncOp addFunction(mlir::OpBuilder &builder, mlir::ModuleOp module,
@@ -44,6 +45,5 @@ private:
 };
 
 /// Generate unique name for llvm global based on provided srcName.
-std::string getUniqueLLVMGlobalName(mlir::ModuleOp mod,
-                                    mlir::StringRef srcName);
+std::string getUniqueLLVMGlobalName(mlir::ModuleOp mod, llvm::Twine srcName);
 } // namespace numba

--- a/mlir/lib/Conversion/GpuRuntimeToLlvm.cpp
+++ b/mlir/lib/Conversion/GpuRuntimeToLlvm.cpp
@@ -43,8 +43,10 @@ struct FunctionCallBuilder {
       return function;
 
     auto body = module.getBody();
-    return mlir::OpBuilder::atBlockBegin(body).create<mlir::LLVM::LLVMFuncOp>(
-        loc, functionName, functionType);
+    mlir::OpBuilder::InsertionGuard g(builder);
+    builder.setInsertionPoint(body, body->end());
+    return builder.create<mlir::LLVM::LLVMFuncOp>(loc, functionName,
+                                                  functionType);
   }
 
   mlir::StringRef getName() const { return functionName; }

--- a/mlir/lib/Conversion/GpuRuntimeToLlvm.cpp
+++ b/mlir/lib/Conversion/GpuRuntimeToLlvm.cpp
@@ -711,9 +711,8 @@ private:
     mlir::Value event = rewriter.create<mlir::LLVM::ExtractValueOp>(
         loc, llvmPointerType, res, 1);
 
-    deallocCallBuilder.createFunc(loc, rewriter);
-    auto dtor = mlir::SymbolRefAttr::get(
-        rewriter.getStringAttr(deallocCallBuilder.getName()));
+    auto deallocFunc = deallocCallBuilder.createFunc(loc, rewriter);
+    auto dtor = mlir::SymbolRefAttr::get(deallocFunc);
     mlir::Value meminfo = rewriter.create<numba::util::WrapAllocatedPointer>(
         loc, llvmPointerType, dataPtr, dtor, stream);
 

--- a/mlir/lib/Conversion/GpuRuntimeToLlvm.cpp
+++ b/mlir/lib/Conversion/GpuRuntimeToLlvm.cpp
@@ -5,6 +5,7 @@
 #include "numba/Conversion/GpuRuntimeToLlvm.hpp"
 
 #include "numba/Dialect/gpu_runtime/IR/GpuRuntimeOps.hpp"
+#include "numba/Dialect/numba_util/Dialect.hpp"
 #include "numba/Transforms/FuncUtils.hpp"
 #include "numba/Transforms/TypeConversion.hpp"
 
@@ -28,17 +29,27 @@ struct FunctionCallBuilder {
             mlir::LLVM::LLVMFunctionType::get(returnType, argumentTypes)) {}
   mlir::LLVM::CallOp create(mlir::Location loc, mlir::OpBuilder &builder,
                             mlir::ArrayRef<mlir::Value> arguments) const {
-    auto module =
-        builder.getBlock()->getParent()->getParentOfType<mlir::ModuleOp>();
-    auto function = [&] {
-      if (auto function =
-              module.lookupSymbol<mlir::LLVM::LLVMFuncOp>(functionName))
-        return function;
-      return mlir::OpBuilder::atBlockEnd(module.getBody())
-          .create<mlir::LLVM::LLVMFuncOp>(loc, functionName, functionType);
-    }();
+    auto function = createFunc(loc, builder);
     return builder.create<mlir::LLVM::CallOp>(loc, function, arguments);
   }
+  mlir::LLVM::LLVMFuncOp createFunc(mlir::Location loc,
+                                    mlir::OpBuilder &builder) const {
+    auto module =
+        builder.getBlock()->getParent()->getParentOfType<mlir::ModuleOp>();
+    assert(module);
+
+    if (auto function =
+            module.lookupSymbol<mlir::LLVM::LLVMFuncOp>(functionName))
+      return function;
+
+    auto body = module.getBody();
+    mlir::OpBuilder::InsertionGuard g(builder);
+    builder.setInsertionPoint(body, body->end());
+    return builder.create<mlir::LLVM::LLVMFuncOp>(loc, functionName,
+                                                  functionType);
+  }
+
+  mlir::StringRef getName() const { return functionName; }
 
 private:
   mlir::StringRef functionName;
@@ -77,7 +88,7 @@ protected:
       context, {llvmPointerType, llvmInt32Type, llvmInt32Type});
   mlir::Type llvmGpuParamPointerType = getLLVMPointerType(llvmGpuParamType);
   mlir::Type llvmAllocResType = mlir::LLVM::LLVMStructType::getLiteral(
-      context, {llvmPointerType, llvmPointerType, llvmPointerType});
+      context, {llvmPointerType, llvmPointerType});
   mlir::Type llvmAllocResPtrType = getLLVMPointerType(llvmAllocResType);
 
   FunctionCallBuilder streamCreateCallBuilder = {
@@ -695,10 +706,16 @@ private:
     allocCallBuilder.create(loc, rewriter, params);
     auto res =
         rewriter.create<mlir::LLVM::LoadOp>(loc, llvmAllocResType, resultPtr);
-    auto meminfo = rewriter.create<mlir::LLVM::ExtractValueOp>(
-        loc, llvmPointerType, res, 0);
     auto dataPtr = rewriter.create<mlir::LLVM::ExtractValueOp>(
+        loc, llvmPointerType, res, 0);
+    mlir::Value event = rewriter.create<mlir::LLVM::ExtractValueOp>(
         loc, llvmPointerType, res, 1);
+
+    deallocCallBuilder.createFunc(loc, rewriter);
+    auto dtor = mlir::SymbolRefAttr::get(
+        rewriter.getStringAttr(deallocCallBuilder.getName()));
+    mlir::Value meminfo = rewriter.create<numba::util::WrapAllocatedPointer>(
+        loc, llvmPointerType, dataPtr, dtor, stream);
 
     auto memrefDesc = mlir::MemRefDescriptor::undef(rewriter, loc, dstType);
     auto elemPtrTye = memrefDesc.getElementPtrType();
@@ -719,8 +736,6 @@ private:
     }
 
     mlir::Value resMemref = memrefDesc;
-    mlir::Value event = rewriter.create<mlir::LLVM::ExtractValueOp>(
-        loc, llvmPointerType, res, 2);
     if (op.getNumResults() == 1) {
       waitEventCallBuilder.create(loc, rewriter, {stream, event});
       destroyEventCallBuilder.create(loc, rewriter, {stream, event});

--- a/mlir/lib/Conversion/GpuRuntimeToLlvm.cpp
+++ b/mlir/lib/Conversion/GpuRuntimeToLlvm.cpp
@@ -43,10 +43,8 @@ struct FunctionCallBuilder {
       return function;
 
     auto body = module.getBody();
-    mlir::OpBuilder::InsertionGuard g(builder);
-    builder.setInsertionPoint(body, body->end());
-    return builder.create<mlir::LLVM::LLVMFuncOp>(loc, functionName,
-                                                  functionType);
+    return mlir::OpBuilder::atBlockBegin(body).create<mlir::LLVM::LLVMFuncOp>(
+        loc, functionName, functionType);
   }
 
   mlir::StringRef getName() const { return functionName; }

--- a/mlir/lib/Conversion/UtilToLlvm.cpp
+++ b/mlir/lib/Conversion/UtilToLlvm.cpp
@@ -591,8 +591,8 @@ struct LowerWrapAllocPointerOp
       // Keep in sync with PythonRt.cpp MemInfoDtorFunction decl.
       auto wrapperFuncType = mlir::LLVM::LLVMFunctionType::get(
           voidType, {ptrType, indexType, ptrType});
-      auto wrapperName = numba::getUniqueLLVMGlobalName(
-          mod, dtorRef.getLeafReference().getValue() + "_wrapper");
+      auto wrapperName =
+          numba::getUniqueLLVMGlobalName(mod, dtorRef + "_wrapper");
       mlir::OpBuilder::InsertionGuard g(rewriter);
       rewriter.setInsertionPointToStart(mod.getBody());
       auto loc = deallocFunc.getLoc();

--- a/mlir/lib/Conversion/UtilToLlvm.cpp
+++ b/mlir/lib/Conversion/UtilToLlvm.cpp
@@ -543,6 +543,89 @@ struct LowerApplyOffsetOp
   }
 };
 
+static mlir::LLVM::LLVMFuncOp
+getAllocMemInfoFunc(mlir::OpBuilder &builder,
+                    const mlir::LLVMTypeConverter &converter,
+                    mlir::ModuleOp mod) {
+  mlir::StringRef funcName = "nmrtAllocMemInfo";
+  auto func = mod.lookupSymbol<mlir::LLVM::LLVMFuncOp>(funcName);
+  if (func)
+    return func;
+
+  auto loc = builder.getUnknownLoc();
+  auto ptr = mlir::LLVM::LLVMPointerType::get(builder.getContext());
+  auto index = converter.getIndexType();
+  auto funcType =
+      mlir::LLVM::LLVMFunctionType::get(ptr, {ptr, index, ptr, ptr});
+
+  mlir::OpBuilder::InsertionGuard g(builder);
+  builder.setInsertionPointToStart(mod.getBody());
+  return builder.create<mlir::LLVM::LLVMFuncOp>(loc, funcName, funcType);
+}
+
+struct LowerWrapAllocPointerOp
+    : public mlir::ConvertOpToLLVMPattern<numba::util::WrapAllocatedPointer> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(numba::util::WrapAllocatedPointer op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    auto mod = op->getParentOfType<mlir::ModuleOp>();
+    if (!mod)
+      return rewriter.notifyMatchFailure(op, "Top level op is not ModuleOp");
+
+    auto dtorRef = adaptor.getDtor();
+    auto deallocFunc = mod.lookupSymbol<mlir::LLVM::LLVMFuncOp>(dtorRef);
+    if (!deallocFunc)
+      return rewriter.notifyMatchFailure(op, [&](mlir::Diagnostic &diag) {
+        diag << "Dealloc function not found " << dtorRef;
+      });
+
+    auto &converter = *getTypeConverter();
+    auto allocMeminfoFunc = getAllocMemInfoFunc(rewriter, converter, mod);
+    auto ptrType = mlir::LLVM::LLVMPointerType::get(rewriter.getContext());
+    auto indexType = converter.getIndexType();
+
+    auto wrapper = [&]() {
+      auto voidType = mlir::LLVM::LLVMVoidType::get(rewriter.getContext());
+      // Keep in sync with PythonRt.cpp MemInfoDtorFunction decl.
+      auto wrapperFuncType = mlir::LLVM::LLVMFunctionType::get(
+          voidType, {ptrType, indexType, ptrType});
+      auto wrapperName = numba::getUniqueLLVMGlobalName(
+          mod, dtorRef.getLeafReference().getValue() + "_wrapper");
+      mlir::OpBuilder::InsertionGuard g(rewriter);
+      rewriter.setInsertionPointToStart(mod.getBody());
+      auto loc = deallocFunc.getLoc();
+      auto func = rewriter.create<mlir::LLVM::LLVMFuncOp>(loc, wrapperName,
+                                                          wrapperFuncType);
+      func.setPrivate();
+      auto block = func.addEntryBlock();
+      rewriter.setInsertionPointToStart(block);
+      auto ptr = block->getArgument(0);
+      auto dtorData = block->getArgument(2);
+      rewriter.create<mlir::LLVM::CallOp>(loc, deallocFunc,
+                                          mlir::ValueRange({dtorData, ptr}));
+      rewriter.create<mlir::LLVM::ReturnOp>(loc, std::nullopt);
+      return func;
+    }();
+
+    auto loc = op.getLoc();
+    mlir::Value wrapperPtr =
+        rewriter.create<mlir::LLVM::AddressOfOp>(loc, wrapper);
+    wrapperPtr =
+        rewriter.create<mlir::LLVM::BitcastOp>(loc, ptrType, wrapperPtr);
+    auto size = rewriter.create<mlir::LLVM::ConstantOp>(loc, indexType, 0);
+    mlir::Value args[] = {
+        adaptor.getPtr(),
+        size,
+        wrapperPtr,
+        adaptor.getDtorData(),
+    };
+    rewriter.replaceOpWithNewOp<mlir::LLVM::CallOp>(op, allocMeminfoFunc, args);
+    return mlir::success();
+  }
+};
+
 /// Convert operations from the numba_util dialect to the LLVM dialect.
 struct NumbaUtilToLLVMPass
     : public mlir::PassWrapper<NumbaUtilToLLVMPass,
@@ -568,7 +651,8 @@ struct NumbaUtilToLLVMPass
         LowerMemrefBitcastOp,
         LowerTakeContextOp,
         LowerReleaseContextOp,
-        LowerApplyOffsetOp
+        LowerApplyOffsetOp,
+        LowerWrapAllocPointerOp
         // clang-format on
         >(typeConverter);
 

--- a/mlir/lib/Dialect/numba_util/Dialect.cpp
+++ b/mlir/lib/Dialect/numba_util/Dialect.cpp
@@ -2167,6 +2167,18 @@ mlir::OpFoldResult MemrefBitcastOp::fold(FoldAdaptor) {
 mlir::OpFoldResult StringConstOp::fold(FoldAdaptor adaptor) {
   return getValueAttr();
 }
+
+mlir::LogicalResult WrapAllocatedPointer::verifySymbolUses(
+    mlir::SymbolTableCollection &symbolTable) {
+  auto fnAttr = getDtorAttr();
+  auto fn = symbolTable.lookupNearestSymbolFrom<mlir::FunctionOpInterface>(
+      *this, fnAttr);
+  if (!fn)
+    return emitOpError() << "'" << fnAttr.getValue()
+                         << "' does not reference a valid function";
+
+  return mlir::success();
+}
 } // namespace util
 } // namespace numba
 

--- a/mlir/lib/Transforms/FuncUtils.cpp
+++ b/mlir/lib/Transforms/FuncUtils.cpp
@@ -35,15 +35,11 @@ numba::AllocaInsertionPoint::AllocaInsertionPoint(mlir::Operation *inst) {
 }
 
 std::string numba::getUniqueLLVMGlobalName(mlir::ModuleOp mod,
-                                           mlir::StringRef srcName) {
-  auto globals = mod.getOps<mlir::LLVM::GlobalOp>();
+                                           llvm::Twine srcName) {
   for (int i = 0;; ++i) {
     auto name =
-        (i == 0 ? std::string(srcName) : (srcName + llvm::Twine(i)).str());
-    auto isSameName = [&](mlir::LLVM::GlobalOp global) {
-      return global.getName() == name;
-    };
-    if (llvm::find_if(globals, isSameName) == globals.end())
+        (i == 0 ? srcName.str() : (srcName + "_" + llvm::Twine(i)).str());
+    if (!mod.lookupSymbol(name))
       return name;
   }
 }

--- a/numba_mlir/numba_mlir/mlir/gpu_runtime.py
+++ b/numba_mlir/numba_mlir/mlir/gpu_runtime.py
@@ -6,6 +6,7 @@ import ctypes
 import atexit
 import logging
 from .utils import load_lib, mlir_func_name, register_cfunc, readenv
+from . import python_rt
 
 from numba.core.runtime import _nrt_python as _nrt
 

--- a/numba_mlir/numba_mlir/mlir/gpu_runtime.py
+++ b/numba_mlir/numba_mlir/mlir/gpu_runtime.py
@@ -39,6 +39,7 @@ if IS_GPU_RUNTIME_AVAILABLE:
     def _register_funcs():
         _funcs = [
             "gpuxAlloc",
+            "gpuxDeAlloc",
             "gpuxKernelDestroy",
             "gpuxKernelGet",
             "gpuxLaunchKernel",

--- a/numba_mlir/numba_mlir/mlir/gpu_runtime.py
+++ b/numba_mlir/numba_mlir/mlir/gpu_runtime.py
@@ -34,7 +34,6 @@ except Exception:
 
 
 if IS_GPU_RUNTIME_AVAILABLE:
-    from .python_rt import get_alloc_func
 
     def _register_funcs():
         _funcs = [
@@ -80,10 +79,6 @@ if IS_GPU_RUNTIME_AVAILABLE:
             else:
                 func = 1
             register_cfunc(name, func)
-
-        _alloc_func = runtime_lib.gpuxSetMemInfoAllocFunc
-        _alloc_func.argtypes = [ctypes.c_void_p]
-        _alloc_func(get_alloc_func())
 
     _register_funcs()
     del _register_funcs

--- a/numba_mlir/numba_mlir/mlir/python_rt.py
+++ b/numba_mlir/numba_mlir/mlir/python_rt.py
@@ -24,9 +24,3 @@ def _register_funcs():
 
 _register_funcs()
 del _register_funcs
-
-_alloc_func = runtime_lib.nmrtAllocMemInfo
-
-
-def get_alloc_func():
-    return ctypes.cast(_alloc_func, ctypes.c_void_p).value

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToLlvm.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToLlvm.cpp
@@ -744,8 +744,7 @@ struct LowerRetainOp
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
   mlir::LogicalResult
-  matchAndRewrite(numba::util::RetainOp op,
-                  numba::util::RetainOp::Adaptor adaptor,
+  matchAndRewrite(numba::util::RetainOp op, OpAdaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
     auto arg = adaptor.getSource();
     if (!arg.getType().isa<mlir::LLVM::LLVMStructType>())
@@ -1606,6 +1605,7 @@ struct LLVMLoweringPass
         });
 
     populateToLLVMAdditionalTypeConversion(typeConverter);
+
     RewritePatternSet patterns(&context);
     populateFuncToLLVMFuncOpConversionPattern(typeConverter, patterns);
     populateFuncToLLVMConversionPatterns(typeConverter, patterns);

--- a/numba_mlir_gpu_common/GpuCommon.hpp
+++ b/numba_mlir_gpu_common/GpuCommon.hpp
@@ -59,7 +59,6 @@ using MemInfoAllocFuncT = void *(*)(void *, size_t, MemInfoDtorFunction,
                                     void *);
 
 struct GPUAllocResult {
-  void *info;
   void *ptr;
   void *event;
 };

--- a/numba_mlir_gpu_runtime_l0/lib/GpuRuntime.cpp
+++ b/numba_mlir_gpu_runtime_l0/lib/GpuRuntime.cpp
@@ -516,7 +516,7 @@ gpuxAlloc(void *stream, size_t size, size_t alignment, int type, void *events,
     auto res = static_cast<Stream *>(stream)->allocBuffer(
         size, alignment, static_cast<numba::GpuAllocType>(type),
         static_cast<ze_event_handle_t *>(events), eventIndex, AllocFunc);
-    *ret = {std::get<0>(res), std::get<1>(res), std::get<2>(res)};
+    *ret = {std::get<1>(res), std::get<2>(res)};
   });
 }
 


### PR DESCRIPTION
Instead of setting custom `AllocFunc` to GPU runtime to wrap allocs into numba meminfo, handle wrapping completely on codegen level.