### PR TITLE
FIx some pass convergence issues

### DIFF
--- a/mlir/lib/Transforms/CompositePass.cpp
+++ b/mlir/lib/Transforms/CompositePass.cpp
@@ -31,8 +31,9 @@ struct CompositePass
         return signalPassFailure();
 
       if (currentIter++ >= maxIters) {
-        //        op->emitWarning("Composite pass didn't converge in " +
-        //                        llvm::Twine(maxIters) + " iterations");
+        op->emitWarning("Composite pass \"" + llvm::Twine(name) +
+                        "\"+ didn't converge in " + llvm::Twine(maxIters) +
+                        " iterations");
         break;
       }
 

--- a/mlir/lib/Transforms/LoopUtils.cpp
+++ b/mlir/lib/Transforms/LoopUtils.cpp
@@ -302,6 +302,9 @@ LogicalResult numba::prepareForFusion(
         }
 
         bool canMove = [&]() {
+          if (currentOp.hasTrait<mlir::OpTrait::ConstantLike>())
+            return false;
+
           if (!hasNoEffect(&currentOp))
             return false;
 

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -3618,6 +3618,9 @@ struct MoveTrivialIntoRegionPass
           !op->getRegions().empty())
         return false;
 
+      if (op->hasTrait<mlir::OpTrait::ConstantLike>())
+        return false;
+
       if (mlir::isa<mlir::ViewLikeOpInterface>(op))
         return true;
 


### PR DESCRIPTION
* Do not move constants in `prepareForFusion` and `MoveTrivialIntoRegionPass` as it causes fight with canonicalizer