### PR TITLE
Move `LowerCopyOpsPass`

### DIFF
--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -4219,16 +4219,13 @@ static void populatePlierToLinalgOptPipeline(mlir::OpPassManager &pm) {
 
   pm.addNestedPass<mlir::func::FuncOp>(
       std::make_unique<MakeGenericReduceInnermostPass>());
+  pm.addNestedPass<mlir::func::FuncOp>(std::make_unique<LowerCopyOpsPass>());
   pm.addNestedPass<mlir::func::FuncOp>(
       mlir::createConvertLinalgToParallelLoopsPass());
   pm.addNestedPass<mlir::func::FuncOp>(
       std::make_unique<ReplaceMemrefPoisonPass>());
   pm.addNestedPass<mlir::func::FuncOp>(mlir::createCanonicalizerPass());
 
-  pm.addNestedPass<mlir::func::FuncOp>(std::make_unique<LowerCopyOpsPass>());
-  pm.addNestedPass<mlir::func::FuncOp>(
-      mlir::createConvertLinalgToParallelLoopsPass());
-  pm.addNestedPass<mlir::func::FuncOp>(mlir::createCanonicalizerPass());
   pm.addPass(numba::createForceInlinePass());
   pm.addPass(mlir::createSymbolDCEPass());
 


### PR DESCRIPTION
This was probably a remnant of old deallocation pipeline, which was reworked recently.
Move pass before `createConvertLinalgToParallelLoopsPass`, this allows to get rid of second `createConvertLinalgToParallelLoopsPass` and canon passes.
