### PR TITLE
Introduce custom reshape op

### DIFF
--- a/mlir/include/numba/Dialect/numba_util/NumbaUtilOps.td
+++ b/mlir/include/numba/Dialect/numba_util/NumbaUtilOps.td
@@ -396,4 +396,24 @@ def GetAllocTokenOp : NumbaUtil_Op<"get_alloc_token", [
   }];
 }
 
+def ReshapeOp : NumbaUtil_Op<"reshape", [
+    Pure, ViewLikeOpInterface]> {
+
+  let arguments = (ins
+    AnyShaped:$source,
+    Variadic<Index>:$shape
+  );
+  let results = (outs AnyShaped:$result);
+
+  let extraClassDeclaration = [{
+      ::mlir::Value getViewSource() { return getSource(); }
+  }];
+
+
+  let assemblyFormat = [{
+    $source `(` $shape `)` attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+
 #endif // PLIER_UTIL_OPS

--- a/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
+++ b/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
@@ -216,11 +216,6 @@ public:
     }
 
     if (auto reshape = mlir::dyn_cast<numba::util::ReshapeOp>(op)) {
-      auto srcShaped =
-          mlir::dyn_cast<mlir::ShapedType>(reshape.getSource().getType());
-      if (!srcShaped)
-        return;
-
       auto dstShaped =
           mlir::dyn_cast<mlir::ShapedType>(reshape.getResult().getType());
       if (!dstShaped)
@@ -244,15 +239,7 @@ public:
         ranges.emplace_back(value.getValue());
       }
 
-      ShapeValue newVal(ranges);
-      newVal = ShapeValue::intersect(newVal, {srcShaped});
-      newVal = ShapeValue::intersect(newVal, {dstShaped});
-
-      auto inputLatticeVal = operands.front()->getValue();
-      if (inputLatticeVal.isUninitialized())
-        return;
-
-      newVal = ShapeValue::intersect(newVal, inputLatticeVal);
+      auto newVal = ShapeValue::intersect({ranges}, {dstShaped});
 
       LLVM_DEBUG(llvm::dbgs() << "ShapeValueAnalysis: New reshape result: "
                               << newVal << "\n");

--- a/mlir/test/Transforms/shape-int-range-opts.mlir
+++ b/mlir/test/Transforms/shape-int-range-opts.mlir
@@ -111,8 +111,7 @@ func.func @test(%arg1: tensor<?xf32> {numba.shape_range = [#numba_util.index_ran
 func.func @test(%arg1: tensor<?xf32>) -> i1 {
   %cst0 = arith.constant 0 : index
   %cst1 = arith.constant 1 : index
-  %0 = tensor.from_elements %cst0, %cst1 : tensor<2xindex>
-  %1 = tensor.reshape %arg1(%0) : (tensor<?xf32>, tensor<2xindex>) -> tensor<?x?xf32>
+  %1 = numba_util.reshape %arg1(%cst0, %cst1) : (tensor<?xf32>, index, index) -> tensor<?x?xf32>
   %2 = tensor.dim %1, %cst0 : tensor<?x?xf32>
   %3 = arith.cmpi eq, %2, %cst1 : index
   return %3: i1
@@ -126,8 +125,7 @@ func.func @test(%arg1: tensor<?xf32>) -> i1 {
 func.func @test(%arg1: tensor<?xf32>) -> i1 {
   %cst0 = arith.constant 0 : index
   %cst1 = arith.constant 1 : index
-  %0 = tensor.from_elements %cst0, %cst1 : tensor<2xindex>
-  %1 = tensor.reshape %arg1(%0) : (tensor<?xf32>, tensor<2xindex>) -> tensor<?x?xf32>
+  %1 = numba_util.reshape %arg1(%cst0, %cst1) : (tensor<?xf32>, index, index) -> tensor<?x?xf32>
   %2 = tensor.dim %1, %cst1 : tensor<?x?xf32>
   %3 = arith.cmpi eq, %2, %cst0 : index
   return %3: i1

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/PyLinalgResolver.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/PyLinalgResolver.cpp
@@ -1036,11 +1036,8 @@ static py::object reshapeImpl(py::capsule context, py::handle src,
     return values;
   };
 
-  auto shapeTensor =
-      builder.create<mlir::tensor::FromElementsOp>(loc, toValues(newDimsVals));
-
-  mlir::Value reshaped = builder.create<mlir::tensor::ReshapeOp>(
-      loc, resultType, srcVal, shapeTensor);
+  mlir::Value reshaped = builder.create<numba::util::ReshapeOp>(
+      loc, resultType, srcVal, toValues(newDimsVals));
 
   return ctx.context.createVar(context, reshaped);
 }


### PR DESCRIPTION
* Upstream memref/tensor reshape ops take new shape as a tensor/memref which complicates analysis and can cause unwanted allocations and leads to generally worse codegen.
* New reshape op takes new shape values directly.
* Remove `TensorValueAnalysis` as is sole purpose was to analyse reshape reshape shape tensors.