### PR TITLE
Do not run mlir pipeline for nested compiles

### DIFF
--- a/numba_mlir/numba_mlir/mlir/lowering.py
+++ b/numba_mlir/numba_mlir/mlir/lowering.py
@@ -23,24 +23,27 @@ from .math_runtime import *
 from .numba_runtime import *
 from .gpu_runtime import *
 
+from .utils import scoped_time
+
 import llvmlite.ir as ir
 import llvmlite.binding as llvm
 
 
 class mlir_lower(orig_Lower):
     def lower(self):
-        if USE_MLIR:
-            self.emit_environment_object()
-            self.genlower = None
-            self.lower_normal_function(self.fndesc)
-            self.context.post_lowering(self.module, self.library)
+        with scoped_time(self.lower) as t:
+            if USE_MLIR:
+                self.emit_environment_object()
+                self.genlower = None
+                self.lower_normal_function(self.fndesc)
+                self.context.post_lowering(self.module, self.library)
 
-            # Skip check that all numba symbols defined
-            setattr(self.library, "_verify_declare_only_symbols", lambda: None)
+                # Skip check that all numba symbols defined
+                setattr(self.library, "_verify_declare_only_symbols", lambda: None)
 
-            self.library.add_ir_module(self.module)
-        else:
-            super().lower(self)
+                self.library.add_ir_module(self.module)
+            else:
+                super().lower(self)
 
     def lower_normal_function(self, fndesc):
         if USE_MLIR:

--- a/numba_mlir/numba_mlir/mlir/lowering.py
+++ b/numba_mlir/numba_mlir/mlir/lowering.py
@@ -31,19 +31,18 @@ import llvmlite.binding as llvm
 
 class mlir_lower(orig_Lower):
     def lower(self):
-        with scoped_time(self.lower) as t:
-            if USE_MLIR:
-                self.emit_environment_object()
-                self.genlower = None
-                self.lower_normal_function(self.fndesc)
-                self.context.post_lowering(self.module, self.library)
+        if USE_MLIR:
+            self.emit_environment_object()
+            self.genlower = None
+            self.lower_normal_function(self.fndesc)
+            self.context.post_lowering(self.module, self.library)
 
-                # Skip check that all numba symbols defined
-                setattr(self.library, "_verify_declare_only_symbols", lambda: None)
+            # Skip check that all numba symbols defined
+            setattr(self.library, "_verify_declare_only_symbols", lambda: None)
 
-                self.library.add_ir_module(self.module)
-            else:
-                super().lower(self)
+            self.library.add_ir_module(self.module)
+        else:
+            super().lower(self)
 
     def lower_normal_function(self, fndesc):
         if USE_MLIR:

--- a/numba_mlir/numba_mlir/mlir/passes.py
+++ b/numba_mlir/numba_mlir/mlir/passes.py
@@ -4,6 +4,8 @@
 
 import functools
 
+from time import perf_counter
+
 import llvmlite.ir
 from numba.core import types, cgutils
 from numba.core.compiler import Flags, compile_result
@@ -20,6 +22,14 @@ from .settings import DUMP_IR, OPT_LEVEL, DUMP_DIAGNOSTICS
 from . import func_registry
 from .. import mlir_compiler
 from .compiler_context import global_compiler_context
+
+
+@contextmanager
+def scoped_time(desc):
+    t1 = t2 = perf_counter()
+    yield lambda: t2 - t1
+    t2 = perf_counter()
+    print(f"{str(desc)} took {t2 - t1}")
 
 
 _print_before = []
@@ -106,15 +116,16 @@ class MlirBackendBase(FunctionPass):
         FunctionPass.__init__(self)
 
     def run_pass(self, state):
-        if self._push_func_stack:
-            func_registry.push_active_funcs_stack()
-            try:
-                res = self.run_pass_impl(state)
-            finally:
-                func_registry.pop_active_funcs_stack()
-            return res
-        else:
-            return self.run_pass_impl(state)
+        with scoped_time(self.run_pass) as t:
+            if self._push_func_stack:
+                func_registry.push_active_funcs_stack()
+                try:
+                    res = self.run_pass_impl(state)
+                finally:
+                    func_registry.pop_active_funcs_stack()
+                return res
+            else:
+                return self.run_pass_impl(state)
 
     def _resolve_func_name(self, state, obj):
         name, func, flags = self._resolve_func_impl(state, obj)

--- a/numba_mlir/numba_mlir/mlir/passes.py
+++ b/numba_mlir/numba_mlir/mlir/passes.py
@@ -106,16 +106,15 @@ class MlirBackendBase(FunctionPass):
         FunctionPass.__init__(self)
 
     def run_pass(self, state):
-        with scoped_time(self.run_pass) as t:
-            if self._push_func_stack:
-                func_registry.push_active_funcs_stack()
-                try:
-                    res = self.run_pass_impl(state)
-                finally:
-                    func_registry.pop_active_funcs_stack()
-                return res
-            else:
-                return self.run_pass_impl(state)
+        if self._push_func_stack:
+            func_registry.push_active_funcs_stack()
+            try:
+                res = self.run_pass_impl(state)
+            finally:
+                func_registry.pop_active_funcs_stack()
+            return res
+        else:
+            return self.run_pass_impl(state)
 
     def _resolve_func_name(self, state, obj):
         name, func, flags = self._resolve_func_impl(state, obj)

--- a/numba_mlir/numba_mlir/mlir/passes.py
+++ b/numba_mlir/numba_mlir/mlir/passes.py
@@ -4,8 +4,6 @@
 
 import functools
 
-from time import perf_counter
-
 import llvmlite.ir
 from numba.core import types, cgutils
 from numba.core.compiler import Flags, compile_result
@@ -22,15 +20,7 @@ from .settings import DUMP_IR, OPT_LEVEL, DUMP_DIAGNOSTICS
 from . import func_registry
 from .. import mlir_compiler
 from .compiler_context import global_compiler_context
-
-
-@contextmanager
-def scoped_time(desc):
-    t1 = t2 = perf_counter()
-    yield lambda: t2 - t1
-    t2 = perf_counter()
-    print(f"{str(desc)} took {t2 - t1}")
-
+from .utils import scoped_time
 
 _print_before = []
 _print_after = []

--- a/numba_mlir/numba_mlir/mlir/target.py
+++ b/numba_mlir/numba_mlir/mlir/target.py
@@ -248,7 +248,6 @@ class NumbaMLIRDispatcher(Dispatcher):
         return tp
 
     def compile(self, *args, **kwargs):
-        print(is_nested_compile())
         if is_nested_compile():
             return self._dummy_compile(*args, **kwargs)
 

--- a/numba_mlir/numba_mlir/mlir/target.py
+++ b/numba_mlir/numba_mlir/mlir/target.py
@@ -195,8 +195,10 @@ tls_state.compiler_nest = 0
 @contextmanager
 def compile_scope():
     tls_state.compiler_nest += 1
-    yield None
-    tls_state.compiler_nest -= 1
+    try:
+        yield tls_state.compiler_nest
+    finally:
+        tls_state.compiler_nest -= 1
 
 
 def is_nested_compile():

--- a/numba_mlir/numba_mlir/mlir/target.py
+++ b/numba_mlir/numba_mlir/mlir/target.py
@@ -226,11 +226,6 @@ class NumbaMLIRDispatcher(Dispatcher):
             py_func, self.targetdescr, targetoptions, locals, dummy_compiler_pipeline
         )
 
-        # if pipeline_class is not dummy_compiler_pipeline:
-        #     self._dummy_dispatcher = NumbaMLIRDispatcher(py_func, locals, targetoptions, impl_kind, dummy_compiler_pipeline)
-        # else:
-        #     self._dummy_dispatcher = None
-
     def typeof_pyval(self, val):
         """
         Resolve the Numba type of Python value *val*.

--- a/numba_mlir/numba_mlir/mlir/utils.py
+++ b/numba_mlir/numba_mlir/mlir/utils.py
@@ -87,4 +87,4 @@ def scoped_time(desc):
     t1 = t2 = perf_counter()
     yield lambda: t2 - t1
     t2 = perf_counter()
-    print(f"{str(desc)} took {t2 - t1} sec")
+    print(f"{str(desc)} took {(t2 - t1):.3f} sec")

--- a/numba_mlir/numba_mlir/mlir/utils.py
+++ b/numba_mlir/numba_mlir/mlir/utils.py
@@ -8,6 +8,8 @@ import numba_mlir
 import os
 import sys
 import warnings
+from time import perf_counter
+from contextlib import contextmanager
 import llvmlite.binding as ll
 from .. import mlir_compiler
 
@@ -78,3 +80,11 @@ def readenv(name, ctor, default):
             RuntimeWarning,
         )
         return default
+
+
+@contextmanager
+def scoped_time(desc):
+    t1 = t2 = perf_counter()
+    yield lambda: t2 - t1
+    t2 = perf_counter()
+    print(f"{str(desc)} took {t2 - t1} sec")

--- a/numba_mlir/numba_mlir/mlir/utils.py
+++ b/numba_mlir/numba_mlir/mlir/utils.py
@@ -88,3 +88,15 @@ def scoped_time(desc):
     yield lambda: t2 - t1
     t2 = perf_counter()
     print(f"{str(desc)} took {(t2 - t1):.3f} sec")
+
+
+def print_numba_pass_timings(dispatcher):
+    sigs = dispatcher.signatures
+    if not sigs:
+        return
+
+    md = dispatcher.get_metadata(sigs[-1])
+    for pipeline, timings in md["pipeline_times"].items():
+        print("pipeline:", pipeline)
+        for p, t in timings.items():
+            print("  ", p, f"{t.run:.3f} sec")

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -732,7 +732,6 @@ private:
   }
 
   void lowerBlock(py::handle irBlock) {
-    TIME_FUNC();
     for (auto it : getBody(irBlock))
       lowerInst(it);
   }

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -62,6 +62,7 @@
 
 namespace py = pybind11;
 namespace {
+#if 0 // Enable func timings
 struct Timer {
   using clock = std::chrono::high_resolution_clock;
 
@@ -87,7 +88,10 @@ private:
 };
 thread_local int Timer::depth = 0;
 
-#define TIME_FUNC() Timer t(__func__)
+#define TIME_FUNC() Timer _scope_timer(__func__)
+#else
+#define TIME_FUNC() (void)0
+#endif
 
 class dummy_complex : public py::object {
 public:

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -65,19 +65,27 @@ namespace {
 struct Timer {
   using clock = std::chrono::high_resolution_clock;
 
-  Timer(const char *name_) : name(name_), begin(clock::now()) {}
+  Timer(const char *name_) : name(name_), begin(clock::now()) { ++depth; }
 
   ~Timer() {
+    auto d = --depth;
     auto end = clock::now();
     auto dur =
         std::chrono::duration_cast<std::chrono::milliseconds>(end - begin);
+    for (auto i : llvm::seq(0, d)) {
+      (void)i;
+      llvm::errs() << "  ";
+    }
+
     llvm::errs() << name << " took " << dur.count() << "ms\n";
   }
 
 private:
   const char *name;
   clock::time_point begin;
+  static thread_local int depth;
 };
+thread_local int Timer::depth = 0;
 
 #define TIME_FUNC() Timer t(__func__)
 

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -1395,9 +1395,29 @@ private:
     return opts;
   }
 };
+
+struct Timer {
+  using clock = std::chrono::high_resolution_clock;
+
+  Timer(const char *name_) : name(name_), begin(clock::now()) {}
+
+  ~Timer() {
+    auto end = clock::now();
+    auto dur =
+        std::chrono::duration_cast<std::chrono::milliseconds>(end - begin);
+    llvm::errs() << name << " took " << dur.count() << "ms\n";
+  }
+
+private:
+  const char *name;
+  clock::time_point begin;
+};
+
+#define TIME_FUNC() Timer t(__func__)
 } // namespace
 
 py::capsule initCompiler(py::dict settings) {
+  TIME_FUNC();
   auto debugType = settings["debug_type"].cast<py::list>();
   auto debugTypeSize = debugType.size();
   if (debugTypeSize != 0) {
@@ -1427,6 +1447,7 @@ static bool getDictVal(py::dict &dict, const char *str, T &&def) {
 }
 
 py::capsule createModule(py::dict settings) {
+  TIME_FUNC();
   ModuleSettings modSettings;
   modSettings.enableGpuPipeline =
       getDictVal(settings, "enable_gpu_pipeline", false);
@@ -1444,6 +1465,7 @@ py::capsule createModule(py::dict settings) {
 
 py::capsule lowerFunction(const py::object &compilationContext,
                           const py::capsule &pyMod, const py::object &funcIr) {
+  TIME_FUNC();
   auto mod = static_cast<Module *>(pyMod);
   auto &context = mod->context;
   auto &module = mod->module;
@@ -1455,6 +1477,7 @@ py::capsule lowerFunction(const py::object &compilationContext,
 py::capsule lowerParfor(const pybind11::object &compilationContext,
                         const pybind11::capsule &pyMod,
                         const pybind11::object &parforInst) {
+  TIME_FUNC();
   auto mod = static_cast<Module *>(pyMod);
   auto &context = mod->context;
   auto &module = mod->module;
@@ -1466,6 +1489,7 @@ py::capsule lowerParfor(const pybind11::object &compilationContext,
 py::capsule compileModule(const py::capsule &compiler,
                           const py::object &compilationContext,
                           const py::capsule &pyMod) {
+  TIME_FUNC();
   auto context = static_cast<GlobalCompilerContext *>(compiler);
   assert(context);
   auto mod = static_cast<Module *>(pyMod);
@@ -1495,6 +1519,7 @@ void registerSymbol(const py::capsule &compiler, const py::str &name,
 
 py::int_ getFunctionPointer(const py::capsule &compiler,
                             const py::capsule &module, py::str funcName) {
+  TIME_FUNC();
   auto context = static_cast<GlobalCompilerContext *>(compiler);
   assert(context);
   auto handle = static_cast<numba::ExecutionEngine::ModuleHandle *>(module);
@@ -1510,6 +1535,7 @@ py::int_ getFunctionPointer(const py::capsule &compiler,
 }
 
 void releaseModule(const py::capsule &compiler, const py::capsule &module) {
+  TIME_FUNC();
   auto context = static_cast<GlobalCompilerContext *>(compiler);
   assert(context);
   auto handle = static_cast<numba::ExecutionEngine::ModuleHandle *>(module);


### PR DESCRIPTION
* We don't actually use compile results, we only need it for type inference to succeed, so run a dummy pipeline instead
* Add some timing utils to the code