### PR TITLE
`np.linalg.inv`

### DIFF
--- a/numba_mlir/numba_mlir/math_runtime/lib/NumpyLinalg.cpp
+++ b/numba_mlir/numba_mlir/math_runtime/lib/NumpyLinalg.cpp
@@ -212,6 +212,8 @@ GEMM_VARIANT(double, d, float64)
 
 INV_VARIANT(float, s, float32)
 INV_VARIANT(double, d, float64)
+INV_VARIANT(MKL_Complex8, c, complex64)
+INV_VARIANT(MKL_Complex16, z, complex128)
 
 #undef INV_VARIANT
 }

--- a/numba_mlir/numba_mlir/math_runtime/lib/NumpyLinalg.cpp
+++ b/numba_mlir/numba_mlir/math_runtime/lib/NumpyLinalg.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <cassert>
 #include <stdio.h>
 #include <string_view>
 
@@ -34,6 +35,43 @@ void eigImpl(Memref<2, const T> *input, Memref<1, T> *vals,
 #endif
 }
 
+template <typename T>
+static void checkSquare(const Memref<2, T> *arr, char arrName) {
+  if (arr->dims[0] != arr->dims[1]) {
+    fatal_failure("Array '%c' is not square,  dims are %d and %d.\n", arrName,
+                  int(arr->dims[0]), int(arr->dims[1]));
+  }
+};
+
+template <typename T>
+static bool isEmpty2d(const Memref<2, T> *arr, char arrName) {
+  if (arr->dims[0] < 0 || arr->dims[1] < 0) {
+    fatal_failure("Array dims must not be negative. '%c' dims are %d and %d.\n",
+                  arrName, int(arr->dims[0]), int(arr->dims[1]));
+  }
+  return arr->dims[0] == 0 && arr->dims[1] == 0;
+};
+
+template <typename T>
+static void isContiguous2d(const Memref<2, T> *arr, char arrName) {
+  if (arr->strides[0] <= 0 || arr->strides[1] <= 0) {
+    fatal_failure("Strides must be positive. '%c' strides are %d and %d.\n",
+                  arrName, int(arr->strides[0]), int(arr->strides[1]));
+  }
+
+  if (arr->strides[0] != 1 && arr->strides[1] != 1) {
+    fatal_failure(
+        "mkl gemm suports only arrays contiguous on inner dimension.\n"
+        "stride for at least one dimension should be equal to 1.\n"
+        "'%c' parameter is not contiguous. '%c' strides are %d and %d.\n",
+        arrName, arrName, int(arr->strides[0]), int(arr->strides[1]));
+  }
+};
+
+template <typename T> static bool isRowm(const Memref<2, T> *arr) {
+  return arr->strides[1] == 1;
+};
+
 #ifdef NUMBA_MLIR_USE_MKL
 template <typename T>
 using GemmFunc = void(const CBLAS_LAYOUT, const CBLAS_TRANSPOSE,
@@ -44,39 +82,17 @@ using GemmFunc = void(const CBLAS_LAYOUT, const CBLAS_TRANSPOSE,
 template <typename T>
 static void cpuGemm(GemmFunc<T> Gemm, const Memref<2, T> *a,
                     const Memref<2, T> *b, Memref<2, T> *c, T alpha, T beta) {
-  auto isEmpty = [](const Memref<2, T> *arr, char arrName) {
-    if (arr->dims[0] < 0 || arr->dims[1] < 0) {
-      fatal_failure(
-          "Array dims must not be negative. '%c' dims are %d and %d.\n",
-          arrName, int(arr->dims[0]), int(arr->dims[1]));
-    }
-    return arr->dims[0] == 0 && arr->dims[1] == 0;
-  };
+  assert(a);
+  assert(b);
+  assert(c);
 
   // Special case when we matmul empty arrays. Nothing to do in this case.
-  if (isEmpty(a, 'a') && isEmpty(b, 'b'))
+  if (isEmpty2d(a, 'a') && isEmpty2d(b, 'b'))
     return;
 
-  auto isContiguous = [](const Memref<2, T> *arr, char arrName) {
-    if (arr->strides[0] <= 0 || arr->strides[1] <= 0) {
-      fatal_failure("Strides must be positive. '%c' strides are %d and %d.\n",
-                    arrName, int(arr->strides[0]), int(arr->strides[1]));
-    }
-
-    if (arr->strides[0] != 1 && arr->strides[1] != 1) {
-      fatal_failure(
-          "mkl gemm suports only arrays contiguous on inner dimension.\n"
-          "stride for at least one dimension should be equal to 1.\n"
-          "'%c' parameter is not contiguous. '%c' strides are %d and %d.\n",
-          arrName, arrName, int(arr->strides[0]), int(arr->strides[1]));
-    }
-  };
-
-  isContiguous(a, 'a');
-  isContiguous(b, 'b');
-  isContiguous(c, 'c');
-
-  auto isRowm = [](const Memref<2, T> *arr) { return arr->strides[1] == 1; };
+  isContiguous2d(a, 'a');
+  isContiguous2d(b, 'b');
+  isContiguous2d(c, 'c');
 
   auto layout = isRowm(c) ? CblasRowMajor : CblasColMajor;
   auto transA = isRowm(a) == isRowm(c) ? CblasNoTrans : CblasTrans;
@@ -111,6 +127,36 @@ static void cpuGemm(GemmFunc<T> Gemm, const Memref<2, T> *a,
   );
 }
 
+template <typename T>
+using GetrfFunc = lapack_int(int, lapack_int, lapack_int, T *, lapack_int,
+                             lapack_int *);
+template <typename T>
+using GetriFunc = lapack_int(int, lapack_int, T *, lapack_int,
+                             const lapack_int *);
+
+template <typename T>
+static int cpuInv(GetrfFunc<T> getrf, GetriFunc<T> getri, Memref<2, T> *a,
+                  Memref<1, int64_t> *ipiv) {
+  assert(a);
+  assert(ipiv);
+
+  // Nothing to do for empty arrays.
+  if (isEmpty2d(a, 'a'))
+    return 0;
+
+  checkSquare(a, 'a');
+
+  auto n = static_cast<MKL_INT>(a->dims[0]);
+
+  auto layout = isRowm(a) ? CblasRowMajor : CblasColMajor;
+  auto lda = static_cast<MKL_INT>(isRowm(a) ? a->strides[0] : a->strides[1]);
+
+  if (auto res = getrf(layout, n, n, a->data, lda, ipiv->data))
+    return static_cast<int>(res);
+
+  return static_cast<int>((getri(layout, n, a->data, lda, ipiv->data)));
+}
+
 #endif
 } // namespace
 
@@ -129,13 +175,21 @@ EIG_VARIANT(double, float64)
 
 #ifdef NUMBA_MLIR_USE_MKL
 #define MKL_CALL(f, ...) f(__VA_ARGS__)
+
 #define MKL_GEMM(Prefix) cblas_##Prefix##gemm
+
+#define MKL_GETRF(Prefix) LAPACKE_##Prefix##getrf
+#define MKL_GETRI(Prefix) LAPACKE_##Prefix##getri
 #else
 static inline void ALL_UNUSED(int dummy, ...) { (void)dummy; }
-#define MKL_GEMM(Prefix) 0
 #define MKL_CALL(f, ...)                                                       \
   ALL_UNUSED(0, __VA_ARGS__);                                                  \
   fatal_failure("Math runtime was compiled without MKL support\n");
+
+#define MKL_GEMM(Prefix) 0
+
+#define MKL_GETRF(Prefix) 0
+#define MKL_GETRI(Prefix) 0
 #endif
 
 #define GEMM_VARIANT(T, Prefix, Suff)                                          \
@@ -149,5 +203,15 @@ GEMM_VARIANT(float, s, float32)
 GEMM_VARIANT(double, d, float64)
 
 #undef GEMM_VARIANT
-#undef MKL_CALL
+
+#define INV_VARIANT(T, Prefix, Suff)                                           \
+  NUMBA_MLIR_MATH_RUNTIME_EXPORT void mkl_inv_##Suff(                          \
+      Memref<2, T> *a, Memref<1, int64_t> *ipiv) {                             \
+    MKL_CALL(cpuInv<T>, MKL_GETRF(Prefix), MKL_GETRI(Prefix), a, ipiv);        \
+  }
+
+INV_VARIANT(float, s, float32)
+INV_VARIANT(double, d, float64)
+
+#undef INV_VARIANT
 }

--- a/numba_mlir/numba_mlir/math_runtime/lib/NumpyLinalg.cpp
+++ b/numba_mlir/numba_mlir/math_runtime/lib/NumpyLinalg.cpp
@@ -136,7 +136,7 @@ using GetriFunc = lapack_int(int, lapack_int, T *, lapack_int,
 
 template <typename T>
 static int cpuInv(GetrfFunc<T> getrf, GetriFunc<T> getri, Memref<2, T> *a,
-                  Memref<1, int64_t> *ipiv) {
+                  Memref<1, MKL_INT> *ipiv) {
   assert(a);
   assert(ipiv);
 

--- a/numba_mlir/numba_mlir/math_runtime/lib/NumpyLinalg.cpp
+++ b/numba_mlir/numba_mlir/math_runtime/lib/NumpyLinalg.cpp
@@ -149,12 +149,15 @@ static int cpuInv(GetrfFunc<T> getrf, GetriFunc<T> getri, Memref<2, T> *a,
   auto n = static_cast<MKL_INT>(a->dims[0]);
 
   auto layout = isRowm(a) ? CblasRowMajor : CblasColMajor;
+  auto data = a->data;
+  auto ipivData = ipiv->data;
+
   auto lda = static_cast<MKL_INT>(isRowm(a) ? a->strides[0] : a->strides[1]);
 
-  if (auto res = getrf(layout, n, n, a->data, lda, ipiv->data))
+  if (auto res = getrf(layout, n, n, data, lda, ipivData))
     return static_cast<int>(res);
 
-  return static_cast<int>((getri(layout, n, a->data, lda, ipiv->data)));
+  return static_cast<int>((getri(layout, n, data, lda, ipivData)));
 }
 
 #endif
@@ -206,7 +209,7 @@ GEMM_VARIANT(double, d, float64)
 
 #define INV_VARIANT(T, Prefix, Suff)                                           \
   NUMBA_MLIR_MATH_RUNTIME_EXPORT void mkl_inv_##Suff(                          \
-      Memref<2, T> *a, Memref<1, int64_t> *ipiv) {                             \
+      Memref<2, T> *a, Memref<1, lapack_int> *ipiv) {                          \
     MKL_CALL(cpuInv<T>, MKL_GETRF(Prefix), MKL_GETRI(Prefix), a, ipiv);        \
   }
 

--- a/numba_mlir/numba_mlir/math_runtime/lib/NumpyLinalg.cpp
+++ b/numba_mlir/numba_mlir/math_runtime/lib/NumpyLinalg.cpp
@@ -136,7 +136,7 @@ using GetriFunc = lapack_int(int, lapack_int, T *, lapack_int,
 
 template <typename T>
 static int cpuInv(GetrfFunc<T> getrf, GetriFunc<T> getri, Memref<2, T> *a,
-                  Memref<1, MKL_INT> *ipiv) {
+                  Memref<1, lapack_int> *ipiv) {
   assert(a);
   assert(ipiv);
 

--- a/numba_mlir/numba_mlir/mlir/math_runtime.py
+++ b/numba_mlir/numba_mlir/mlir/math_runtime.py
@@ -28,6 +28,7 @@ def load_function_variants(runtime_lib, func_name, suffixes):
 load_function_variants(runtime_lib, "dpnp_linalg_eig_%s", ["float32", "float64"])
 if MKL_AVAILABLE:
     load_function_variants(runtime_lib, "mkl_gemm_%s", ["float32", "float64"])
+    load_function_variants(runtime_lib, "mkl_inv_%s", ["float32", "float64"])
 if SYCL_MKL_AVAILABLE:
     load_function_variants(
         runtime_sycl_lib, "mkl_gemm_%s_device", ["float32", "float64"]

--- a/numba_mlir/numba_mlir/mlir/math_runtime.py
+++ b/numba_mlir/numba_mlir/mlir/math_runtime.py
@@ -28,7 +28,9 @@ def load_function_variants(runtime_lib, func_name, suffixes):
 load_function_variants(runtime_lib, "dpnp_linalg_eig_%s", ["float32", "float64"])
 if MKL_AVAILABLE:
     load_function_variants(runtime_lib, "mkl_gemm_%s", ["float32", "float64"])
-    load_function_variants(runtime_lib, "mkl_inv_%s", ["float32", "float64"])
+    load_function_variants(
+        runtime_lib, "mkl_inv_%s", ["float32", "float64", "complex64", "complex128"]
+    )
 if SYCL_MKL_AVAILABLE:
     load_function_variants(
         runtime_sycl_lib, "mkl_gemm_%s_device", ["float32", "float64"]

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy_linalg.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy_linalg.py
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import pytest
-import numpy
-from numba_mlir import njit
+import numpy as np
 from numba_mlir.mlir.utils import readenv
+from numbers import Number, Integral
+
+from .utils import njit_cached as njit
 
 DPNP_TESTS_ENABLED = readenv("NUMBA_MLIR_ENABLE_DPNP_TESTS", int, 0)
 
@@ -20,7 +22,7 @@ def vvsort(val, vec, size):
     for i in range(size):
         imax = i
         for j in range(i + 1, size):
-            if numpy.abs(val[imax]) < numpy.abs(val[j]):
+            if np.abs(val[imax]) < np.abs(val[j]):
                 imax = j
 
         temp = val[i]
@@ -34,26 +36,24 @@ def vvsort(val, vec, size):
 
 
 @require_dpnp
-@pytest.mark.parametrize(
-    "type", [numpy.float64, numpy.float32], ids=["float64", "float32"]
-)
+@pytest.mark.parametrize("type", [np.float64, np.float32], ids=["float64", "float32"])
 @pytest.mark.parametrize("size", [2, 4, 8, 16, 300])
 def test_eig_arange(type, size):
-    a = numpy.arange(size * size, dtype=type).reshape((size, size))
+    a = np.arange(size * size, dtype=type).reshape((size, size))
     symm_orig = (
-        numpy.tril(a)
-        + numpy.tril(a, -1).T
-        + numpy.diag(numpy.full((size,), size * size, dtype=type))
+        np.tril(a)
+        + np.tril(a, -1).T
+        + np.diag(np.full((size,), size * size, dtype=type))
     )
     symm = symm_orig.copy()
     dpnp_symm_orig = symm_orig.copy()
     dpnp_symm = symm_orig.copy()
 
     def py_func_val(s):
-        return numpy.linalg.eig(s)[0]
+        return np.linalg.eig(s)[0]
 
     def py_func_vec(s):
-        return numpy.linalg.eig(s)[1]
+        return np.linalg.eig(s)[1]
 
     jit_func_val = njit(py_func_val)
     jit_func_vec = njit(py_func_vec)
@@ -72,13 +72,196 @@ def test_eig_arange(type, size):
         if np_vec[0, i] * dpnp_vec[0, i] < 0:
             np_vec[:, i] = -np_vec[:, i]
 
-    numpy.testing.assert_array_equal(symm_orig, symm)
-    numpy.testing.assert_array_equal(dpnp_symm_orig, dpnp_symm)
+    np.testing.assert_array_equal(symm_orig, symm)
+    np.testing.assert_array_equal(dpnp_symm_orig, dpnp_symm)
 
     assert dpnp_val.dtype == np_val.dtype
     assert dpnp_vec.dtype == np_vec.dtype
     assert dpnp_val.shape == np_val.shape
     assert dpnp_vec.shape == np_vec.shape
 
-    numpy.testing.assert_allclose(dpnp_val, np_val, rtol=1e-05, atol=1e-05)
-    numpy.testing.assert_allclose(dpnp_vec, np_vec, rtol=1e-05, atol=1e-05)
+    np.testing.assert_allclose(dpnp_val, np_val, rtol=1e-05, atol=1e-05)
+    np.testing.assert_allclose(dpnp_vec, np_vec, rtol=1e-05, atol=1e-05)
+
+
+def _sample_vector(n, dtype):
+    # Be careful to generate only exactly representable float values,
+    # to avoid rounding discrepancies between Numpy and Numba
+    base = np.arange(n)
+    if issubclass(dtype, np.complexfloating):
+        return (base * (1 - 0.5j) + 2j).astype(dtype)
+    else:
+        return (base * 0.5 + 1).astype(dtype)
+
+
+def _assert_contig_sanity(got, expected_contig):
+    """
+    This checks that in a computed result from numba (array, possibly tuple
+    of arrays) all the arrays are contiguous in memory and that they are
+    all at least one of "C_CONTIGUOUS" or "F_CONTIGUOUS". The computed
+    result of the contiguousness is then compared against a hardcoded
+    expected result.
+
+    got: is the computed results from numba
+    expected_contig: is "C" or "F" and is the expected type of
+                    contiguousness across all input values
+                    (and therefore tests).
+    """
+
+    if isinstance(got, tuple):
+        # tuple present, check all results
+        for a in got:
+            _assert_contig_sanity(a, expected_contig)
+    else:
+        if not isinstance(got, Number):
+            # else a single array is present
+            c_contig = got.flags.c_contiguous
+            f_contig = got.flags.f_contiguous
+
+            # check that the result (possible set of) is at least one of
+            # C or F contiguous.
+            msg = "Results are not at least one of all C or F contiguous."
+            assert c_contig | f_contig, msg
+
+            msg = "Computed contiguousness does not match expected."
+            if expected_contig == "C":
+                assert c_contig, msg
+            elif expected_contig == "F":
+                assert f_contig, msg
+            else:
+                raise ValueError("Unknown contig")
+
+
+def _assert_is_identity_matrix(got, rtol=None, atol=None):
+    """
+    Checks if a matrix is equal to the identity matrix.
+    """
+    # check it is square
+    assert got.shape[-1] == got.shape[-2]
+    # create identity matrix
+    eye = np.eye(got.shape[-1], dtype=got.dtype)
+    resolution = 5 * np.finfo(got.dtype).resolution
+    if rtol is None:
+        rtol = 10 * resolution
+    if atol is None:
+        atol = 100 * resolution  # zeros tend to be fuzzy
+    # check it matches
+    np.testing.assert_allclose(got, eye, rtol, atol)
+
+
+def _specific_sample_matrix(size, dtype, order, rank=None, condition=None):
+    """
+    Provides a sample matrix with an optionally specified rank or condition
+    number.
+
+    size: (rows, columns), the dimensions of the returned matrix.
+    dtype: the dtype for the returned matrix.
+    order: the memory layout for the returned matrix, 'F' or 'C'.
+    rank: the rank of the matrix, an integer value, defaults to full rank.
+    condition: the condition number of the matrix (defaults to 1.)
+
+    NOTE: Only one of rank or condition may be set.
+    """
+
+    # default condition
+    d_cond = 1.0
+
+    if len(size) != 2:
+        raise ValueError("size must be a length 2 tuple.")
+
+    if order not in ["F", "C"]:
+        raise ValueError("order must be one of 'F' or 'C'.")
+
+    if dtype not in [np.float32, np.float64, np.complex64, np.complex128]:
+        raise ValueError("dtype must be a numpy floating point type.")
+
+    if rank is not None and condition is not None:
+        raise ValueError("Only one of rank or condition can be specified.")
+
+    if condition is None:
+        condition = d_cond
+
+    if condition < 1:
+        raise ValueError("Condition number must be >=1.")
+
+    np.random.seed(0)  # repeatable seed
+    m, n = size
+
+    if m < 0 or n < 0:
+        raise ValueError("Negative dimensions given for matrix shape.")
+
+    minmn = min(m, n)
+    if rank is None:
+        rv = minmn
+    else:
+        if rank <= 0:
+            raise ValueError("Rank must be greater than zero.")
+        if not isinstance(rank, Integral):
+            raise ValueError("Rank must an integer.")
+        rv = rank
+        if rank > minmn:
+            raise ValueError("Rank given greater than full rank.")
+
+    if m == 1 or n == 1:
+        # vector, must be rank 1 (enforced above)
+        # condition of vector is also 1
+        if condition != d_cond:
+            raise ValueError("Condition number was specified for a vector (always 1.).")
+        maxmn = max(m, n)
+        Q = _sample_vector(maxmn, dtype).reshape(m, n)
+    else:
+        # Build a sample matrix via combining SVD like inputs.
+
+        # Create matrices of left and right singular vectors.
+        # This could use Modified Gram-Schmidt and perhaps be quicker,
+        # at present it uses QR decompositions to obtain orthonormal
+        # matrices.
+        tmp = _sample_vector(m * m, dtype).reshape(m, m)
+        U, _ = np.linalg.qr(tmp)
+        # flip the second array, else for m==n the identity matrix appears
+        tmp = _sample_vector(n * n, dtype)[::-1].reshape(n, n)
+        V, _ = np.linalg.qr(tmp)
+        # create singular values.
+        sv = np.linspace(d_cond, condition, rv)
+        S = np.zeros((m, n))
+        idx = np.nonzero(np.eye(m, n))
+        S[idx[0][:rv], idx[1][:rv]] = sv
+        Q = np.dot(np.dot(U, S), V.T)  # construct
+        Q = np.array(Q, dtype=dtype, order=order)  # sort out order/type
+
+    return Q
+
+
+_linalg_dtypes = (np.float64, np.float32, np.complex128, np.complex64)
+
+
+def _inv_checker(py_func, cfunc, a):
+    expected = py_func(a)
+    got = cfunc(a)
+    # _assert_contig_sanity(got, "F")
+
+    use_reconstruction = False
+
+    # try strict
+    try:
+        np.testing.assert_array_almost_equal_nulp(got, expected, nulp=10)
+    except AssertionError:
+        # fall back to reconstruction
+        use_reconstruction = True
+
+    if use_reconstruction:
+        rec = np.dot(got, a)
+        _assert_is_identity_matrix(rec)
+
+
+@pytest.mark.parametrize("n", [0, 10])
+@pytest.mark.parametrize("dtype", _linalg_dtypes)
+@pytest.mark.parametrize("order", "CF")
+def test_linalg_inv(n, dtype, order):
+    def py_func(a):
+        return np.linalg.inv(a)
+
+    jit_func = njit(py_func)
+
+    a = _specific_sample_matrix((n, n), dtype, order)
+    _inv_checker(py_func, jit_func, a)

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy_linalg.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy_linalg.py
@@ -254,7 +254,7 @@ def _inv_checker(py_func, cfunc, a):
         _assert_is_identity_matrix(rec)
 
 
-@pytest.mark.parametrize("n", [0, 10])
+@pytest.mark.parametrize("n", [0, 10, 107])
 @pytest.mark.parametrize("dtype", _linalg_dtypes)
 @pytest.mark.parametrize("order", "CF")
 def test_linalg_inv(n, dtype, order):


### PR DESCRIPTION
Add mkl-lapack-based `np.linalg.inv` impl for float and complex types. Device variants will be added separately. Testing code is taken from Numba.