### PR TITLE
`np.linalg.eig`, `eigvals`, `eigh`, `eigvalsh`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,11 +60,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL Darwin)
     # add_compile_options(-mcet) # v8.0 and newer # unrecognized command line option '-mcet', only recommended
 endif()
 
-option(NUMBA_MLIR_USE_DPNP
-    "Use the dpnp Python NumPy-like library for some math functions"
-    OFF
-)
-
 option(NUMBA_MLIR_USE_MKL
     "Enable mkl support"
     ON
@@ -92,7 +87,6 @@ option(NUMBA_MLIR_ENABLE_TESTS
     OFF
 )
 
-message(STATUS "NUMBA_MLIR_USE_DPNP ${NUMBA_MLIR_USE_DPNP}")
 message(STATUS "NUMBA_MLIR_USE_MKL ${NUMBA_MLIR_USE_MKL}")
 message(STATUS "NUMBA_MLIR_USE_SYCL ${NUMBA_MLIR_USE_SYCL}")
 message(STATUS "NUMBA_MLIR_ENABLE_IGPU_DIALECT ${NUMBA_MLIR_ENABLE_IGPU_DIALECT}")

--- a/numba_mlir/numba_mlir/__init__.py
+++ b/numba_mlir/numba_mlir/__init__.py
@@ -4,8 +4,6 @@
 
 from .decorators import *
 
-from .mlir.settings import DPNP_AVAILABLE
-
 from . import _version
 
 __version__ = _version.get_versions()["version"]

--- a/numba_mlir/numba_mlir/math_runtime/CMakeLists.txt
+++ b/numba_mlir/numba_mlir/math_runtime/CMakeLists.txt
@@ -41,20 +41,3 @@ if(NUMBA_MLIR_USE_MKL)
     target_link_libraries(${PROJECT_NAME} PUBLIC $<LINK_ONLY:MKL::MKL>)
     target_compile_definitions(${PROJECT_NAME} PRIVATE NUMBA_MLIR_USE_MKL=1)
 endif()
-
-if(NUMBA_MLIR_USE_DPNP)
-    target_include_directories(${PROJECT_NAME} PRIVATE
-        ${DPNP_INCLUDE_DIR}
-        )
-
-    target_link_directories(${PROJECT_NAME} PUBLIC ${DPNP_LIBRARY_DIR})
-    target_link_libraries(${PROJECT_NAME} PUBLIC "dpnp_backend_c")
-
-    set(DPNP_RPATH "${DPNP_LIBRARY_DIR}" "$ORIGIN/../dpnp")
-    set_target_properties(${PROJECT_NAME}
-        PROPERTIES
-        INSTALL_RPATH "${DPNP_RPATH}"
-    )
-
-    target_compile_definitions(${PROJECT_NAME} PRIVATE NUMBA_MLIR_USE_DPNP=1)
-endif()

--- a/numba_mlir/numba_mlir/mlir/math_runtime.py
+++ b/numba_mlir/numba_mlir/mlir/math_runtime.py
@@ -32,6 +32,7 @@ if MKL_AVAILABLE:
     load_function_variants(runtime_lib, "mkl_inv_%s", _dtypes)
     load_function_variants(runtime_lib, "mkl_solve_%s", _dtypes)
     load_function_variants(runtime_lib, "mkl_cholesky_%s", _dtypes)
+    load_function_variants(runtime_lib, "mkl_eig_%s", _dtypes)
 if SYCL_MKL_AVAILABLE:
     load_function_variants(
         runtime_sycl_lib, "mkl_gemm_%s_device", ["float32", "float64"]

--- a/numba_mlir/numba_mlir/mlir/math_runtime.py
+++ b/numba_mlir/numba_mlir/mlir/math_runtime.py
@@ -33,6 +33,7 @@ if MKL_AVAILABLE:
     load_function_variants(runtime_lib, "mkl_solve_%s", _dtypes)
     load_function_variants(runtime_lib, "mkl_cholesky_%s", _dtypes)
     load_function_variants(runtime_lib, "mkl_eig_%s", _dtypes)
+    load_function_variants(runtime_lib, "mkl_eigh_%s", _dtypes)
 if SYCL_MKL_AVAILABLE:
     load_function_variants(
         runtime_sycl_lib, "mkl_gemm_%s_device", ["float32", "float64"]

--- a/numba_mlir/numba_mlir/mlir/math_runtime.py
+++ b/numba_mlir/numba_mlir/mlir/math_runtime.py
@@ -25,7 +25,6 @@ def load_function_variants(runtime_lib, func_name, suffixes):
         register_cfunc(mlir_name, func)
 
 
-load_function_variants(runtime_lib, "dpnp_linalg_eig_%s", ["float32", "float64"])
 if MKL_AVAILABLE:
     load_function_variants(runtime_lib, "mkl_gemm_%s", ["float32", "float64"])
 

--- a/numba_mlir/numba_mlir/mlir/numpy/funcs.py
+++ b/numba_mlir/numba_mlir/mlir/numpy/funcs.py
@@ -1262,18 +1262,6 @@ def setitem_impl(builder, arr, index, val):
     return builder.inline_func(func, arr.type, arr, index, val)
 
 
-# @register_func("numpy.linalg.eig", numpy.linalg.eig)
-# def eig_impl(builder, arg):
-#     shape = arg.shape
-#     if len(shape) == 2:
-#         dtype = arg.dtype
-#         func_name = f"dpnp_linalg_eig_{dtype_str(builder, dtype)}"
-#         size = shape[0]
-#         vals = builder.init_tensor([size], dtype)
-#         vecs = builder.init_tensor([size, size], dtype)
-#         return builder.external_call(func_name, arg, (vals, vecs))
-
-
 @register_func("numpy.atleast_2d", numpy.atleast_2d)
 def atleast2d_impl(builder, arr):
     shape = arr.shape

--- a/numba_mlir/numba_mlir/mlir/numpy/funcs.py
+++ b/numba_mlir/numba_mlir/mlir/numpy/funcs.py
@@ -905,6 +905,62 @@ def cholesky_impl(builder, a):
 
 
 @_mkl_func
+def _mkl_eig(builder, a):
+    n = a.shape[0]
+    dtype = a.dtype
+    use_complex = is_complex(dtype, builder)
+
+    func_name = f"mkl_eig_{dtype_str(builder, dtype)}"
+    device_func_name = func_name + "_device"
+
+    a = builder.force_copy(a)
+
+    JOBVL = builder.cast(ord("N"), builder.int8)
+    JOBVR = builder.cast(ord("V"), builder.int8)
+
+    ldvl = 1
+    ldvr = n
+    if use_complex:
+        w = builder.init_tensor((n,), dtype)
+    else:
+        wr = builder.init_tensor((n,), dtype)
+        wi = builder.init_tensor((n,), dtype)
+
+    vl = builder.init_tensor((n, ldvl), dtype)
+    vr = builder.init_tensor((n, ldvr), dtype)
+
+    if use_complex:
+        args = (JOBVL, JOBVR, a, w, vl, vr)
+    else:
+        args = (JOBVL, JOBVR, a, wr, wi, vl, vr)
+
+    res_init = builder.cast(0, builder.int32)
+
+    res = builder.external_call(
+        func_name,
+        args,
+        res_init,
+        attrs={"gpu_runtime.device_func": device_func_name},
+    )
+    # TODO check res
+
+    vr = transpose_impl(builder, vr)
+
+    if use_complex:
+        return (w, vr)
+    else:
+        return (wr, vr)
+
+
+@register_func("numpy.linalg.eig", numpy.linalg.eig)
+def eig_impl(builder, a):
+    if len(a.shape) != 2:
+        return
+
+    return _mkl_eig(builder, a)
+
+
+@_mkl_func
 def _mkl_solve(builder, a, b):
     a_shape = a.shape
     b_shape = b.shape
@@ -1186,16 +1242,16 @@ def setitem_impl(builder, arr, index, val):
     return builder.inline_func(func, arr.type, arr, index, val)
 
 
-@register_func("numpy.linalg.eig", numpy.linalg.eig)
-def eig_impl(builder, arg):
-    shape = arg.shape
-    if len(shape) == 2:
-        dtype = arg.dtype
-        func_name = f"dpnp_linalg_eig_{dtype_str(builder, dtype)}"
-        size = shape[0]
-        vals = builder.init_tensor([size], dtype)
-        vecs = builder.init_tensor([size, size], dtype)
-        return builder.external_call(func_name, arg, (vals, vecs))
+# @register_func("numpy.linalg.eig", numpy.linalg.eig)
+# def eig_impl(builder, arg):
+#     shape = arg.shape
+#     if len(shape) == 2:
+#         dtype = arg.dtype
+#         func_name = f"dpnp_linalg_eig_{dtype_str(builder, dtype)}"
+#         size = shape[0]
+#         vals = builder.init_tensor([size], dtype)
+#         vecs = builder.init_tensor([size, size], dtype)
+#         return builder.external_call(func_name, arg, (vals, vecs))
 
 
 @register_func("numpy.atleast_2d", numpy.atleast_2d)

--- a/numba_mlir/numba_mlir/mlir/settings.py
+++ b/numba_mlir/numba_mlir/mlir/settings.py
@@ -4,7 +4,7 @@
 
 
 from .utils import readenv
-from ..mlir_compiler import is_dpnp_supported, is_mkl_supported, is_sycl_mkl_supported
+from ..mlir_compiler import is_mkl_supported, is_sycl_mkl_supported
 
 
 USE_MLIR = readenv("NUMBA_MLIR_ENABLE", int, 1)
@@ -15,9 +15,6 @@ DUMP_LLVM = readenv("NUMBA_MLIR_DUMP_LLVM", int, 0)
 DUMP_OPTIMIZED = readenv("NUMBA_MLIR_DUMP_OPTIMIZED", int, 0)
 DUMP_ASSEMBLY = readenv("NUMBA_MLIR_DUMP_ASSEMBLY", int, 0)
 DEBUG_TYPE = list(filter(None, readenv("NUMBA_MLIR_DEBUG_TYPE", str, "").split(",")))
-DPNP_AVAILABLE = (
-    is_dpnp_supported()
-)  # TODO: check if dpnp library is available at runtime
 MKL_AVAILABLE = is_mkl_supported()
 SYCL_MKL_AVAILABLE = is_sycl_mkl_supported()
 OPT_LEVEL = readenv("NUMBA_MLIR_OPT_LEVEL", int, 3)

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy_linalg.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy_linalg.py
@@ -461,7 +461,7 @@ def _eig_check_worker(cfunc, name, expected_res_len):
 @pytest.mark.parametrize("n", [0, 10])
 @pytest.mark.parametrize("dtype", _linalg_dtypes)
 @pytest.mark.parametrize("order", "CF")
-@pytest.mark.parametrize("func", ["eig", "eigvals"])
+@pytest.mark.parametrize("func", ["eig", "eigvals", "eigh"])
 def test_linalg_eig(n, dtype, order, func):
     expected_len = 1 if "vals" in func else 2
     func = eval("np.linalg." + func)

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy_linalg.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy_linalg.py
@@ -9,14 +9,6 @@ from numbers import Number, Integral
 
 from .utils import njit_cached as njit
 
-DPNP_TESTS_ENABLED = readenv("NUMBA_MLIR_ENABLE_DPNP_TESTS", int, 0)
-
-
-def require_dpnp(func):
-    return pytest.mark.skipif(not DPNP_TESTS_ENABLED, reason="DPNP tests disabled")(
-        func
-    )
-
 
 def vvsort(val, vec, size):
     for i in range(size):

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy_linalg.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy_linalg.py
@@ -27,7 +27,6 @@ def vvsort(val, vec, size):
             vec[k, imax] = temp
 
 
-@require_dpnp
 @pytest.mark.parametrize("type", [np.float64, np.float32], ids=["float64", "float32"])
 @pytest.mark.parametrize("size", [2, 4, 8, 16, 300])
 def test_eig_arange(type, size):

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy_linalg.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy_linalg.py
@@ -9,6 +9,8 @@ from numbers import Number, Integral
 
 from .utils import njit_cached as njit
 
+_linalg_dtypes = (np.float64, np.float32, np.complex128, np.complex64)
+
 
 def vvsort(val, vec, size):
     for i in range(size):
@@ -27,8 +29,8 @@ def vvsort(val, vec, size):
             vec[k, imax] = temp
 
 
-@pytest.mark.parametrize("type", [np.float64, np.float32], ids=["float64", "float32"])
-@pytest.mark.parametrize("size", [2, 4, 8, 16, 300])
+@pytest.mark.parametrize("type", _linalg_dtypes)
+@pytest.mark.parametrize("size", [2, 4, 8, 16])
 def test_eig_arange(type, size):
     a = np.arange(size * size, dtype=type).reshape((size, size))
     symm_orig = (
@@ -71,8 +73,9 @@ def test_eig_arange(type, size):
     assert dpnp_val.shape == np_val.shape
     assert dpnp_vec.shape == np_vec.shape
 
-    np.testing.assert_allclose(dpnp_val, np_val, rtol=1e-05, atol=1e-05)
-    np.testing.assert_allclose(dpnp_vec, np_vec, rtol=1e-05, atol=1e-05)
+    tol = 1e-03
+    np.testing.assert_allclose(dpnp_val, np_val, rtol=tol, atol=tol)
+    np.testing.assert_allclose(dpnp_vec, np_vec, rtol=tol, atol=tol)
 
 
 def _sample_vector(n, dtype):
@@ -234,9 +237,6 @@ def _specific_sample_matrix(size, dtype, order, rank=None, condition=None):
         Q = np.array(Q, dtype=dtype, order=order)  # sort out order/type
 
     return Q
-
-
-_linalg_dtypes = (np.float64, np.float32, np.complex128, np.complex64)
 
 
 def _inv_checker(py_func, cfunc, a):

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy_linalg.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy_linalg.py
@@ -461,7 +461,7 @@ def _eig_check_worker(cfunc, name, expected_res_len):
 @pytest.mark.parametrize("n", [0, 10])
 @pytest.mark.parametrize("dtype", _linalg_dtypes)
 @pytest.mark.parametrize("order", "CF")
-@pytest.mark.parametrize("func", ["eig", "eigvals", "eigh"])
+@pytest.mark.parametrize("func", ["eig", "eigvals", "eigh", "eigvalsh"])
 def test_linalg_eig(n, dtype, order, func):
     expected_len = 1 if "vals" in func else 2
     func = eval("np.linalg." + func)

--- a/numba_mlir/numba_mlir/mlir_compiler/CMakeLists.txt
+++ b/numba_mlir/numba_mlir/mlir_compiler/CMakeLists.txt
@@ -112,10 +112,6 @@ target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../numba_mlir_gpu_common
     ./lib)
 
-if(NUMBA_MLIR_USE_DPNP)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE NUMBA_MLIR_USE_DPNP=1)
-endif()
-
 if(NUMBA_MLIR_USE_MKL)
     target_compile_definitions(${PROJECT_NAME} PRIVATE NUMBA_MLIR_USE_MKL=1)
 endif()

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/PyModule.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/PyModule.cpp
@@ -8,14 +8,6 @@
 
 #include "Lowering.hpp"
 
-static bool is_dpnp_supported() {
-#ifdef NUMBA_MLIR_USE_DPNP
-  return true;
-#else
-  return false;
-#endif
-}
-
 static bool is_mkl_supported() {
 #ifdef NUMBA_MLIR_USE_MKL
   return true;
@@ -42,7 +34,6 @@ PYBIND11_MODULE(mlir_compiler, m) {
   m.def("get_function_pointer", &getFunctionPointer, "No docs");
   m.def("release_module", &releaseModule, "No docs");
   m.def("module_str", &moduleStr, "No docs");
-  m.def("is_dpnp_supported", &is_dpnp_supported, "No docs");
   m.def("is_mkl_supported", &is_mkl_supported, "No docs");
   m.def("is_sycl_mkl_supported", &is_sycl_mkl_supported, "No docs");
 }

--- a/numba_mlir/setup_helper.py
+++ b/numba_mlir/setup_helper.py
@@ -172,21 +172,6 @@ def build_runtime(install_dir):
     if NUMBA_MLIR_USE_MKL is not None:
         cmake_cmd += ["-DNUMBA_MLIR_USE_MKL=" + NUMBA_MLIR_USE_MKL]
 
-    # DPNP
-    # try:
-    #     from dpnp import get_include as dpnp_get_include
-
-    #     DPNP_LIBRARY_DIR = os.path.join(dpnp_get_include(), "..", "..")
-    #     DPNP_INCLUDE_DIR = dpnp_get_include()
-    #     cmake_cmd += [
-    #         "-DDPNP_LIBRARY_DIR=" + DPNP_LIBRARY_DIR,
-    #         "-DDPNP_INCLUDE_DIR=" + DPNP_INCLUDE_DIR,
-    #         "-DNUMBA_MLIR_USE_DPNP=ON",
-    #     ]
-    #     print("Found DPNP at", DPNP_LIBRARY_DIR)
-    # except ImportError:
-    #     print("DPNP not found")
-
     if NUMBA_MLIR_USE_L0 is not None or NUMBA_MLIR_USE_SYCL is not None:
         print("Enable GPU pipeline")
         cmake_cmd += ["-DNUMBA_MLIR_ENABLE_IGPU_DIALECT=ON"]


### PR DESCRIPTION
Also, remove last remains of dpnp impls, as we are calling MKL directly now.
.