### PR TITLE
Add late MathUpliftToFMA in gpu pipeline 

### DIFF
--- a/numba_mlir/numba_mlir/mlir/tests/test_basic.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_basic.py
@@ -284,7 +284,7 @@ def test_math_uplifting_fma(py_func):
 
         assert_equal(py_func(x, y, z), jit_func(x, y, z))
         ir = get_print_buffer()
-        assert ir.count(f"math.fma") == 1, ir
+        assert ir.count(f"math.fma") > 0, ir
 
 
 @parametrize_function_variants(

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -18,6 +18,7 @@
 #include <mlir/Dialect/GPU/Transforms/Passes.h>
 #include <mlir/Dialect/GPU/Transforms/Utils.h>
 #include <mlir/Dialect/Math/IR/Math.h>
+#include <mlir/Dialect/Math/Transforms/Passes.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/MemRef/Transforms/Passes.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
@@ -2235,6 +2236,7 @@ static void populateLowerToGPUPipelineMed(mlir::OpPassManager &pm) {
   funcPM.addPass(std::make_unique<PrepareForGPUPass>());
   funcPM.addPass(mlir::createCanonicalizerPass());
   funcPM.addPass(std::make_unique<RemoveNestedParallelPass>());
+  funcPM.addPass(mlir::math::createMathUpliftToFMA());
   funcPM.addPass(gpu_runtime::createSortParallelLoopsForGPU());
   funcPM.addPass(gpu_runtime::createTileParallelLoopsForGPUPass());
   funcPM.addPass(gpu_runtime::createInsertGPUGlobalReducePass());


### PR DESCRIPTION
`RemoveNestedParallelPass` converts parallel loops inside kernel into sequential, this can open more opportunities for FMA uplifting if parallel loop contained add-reduction.