### PR TITLE
Add no-sycl-id-queries-fit-in-int to sycl related libraries

### DIFF
--- a/numba_mlir/numba_mlir/math_runtime/sycl/CMakeLists.txt
+++ b/numba_mlir/numba_mlir/math_runtime/sycl/CMakeLists.txt
@@ -57,6 +57,7 @@ if(NUMBA_MLIR_USE_SYCL AND NUMBA_MLIR_USE_MKL)
 
     target_compile_definitions(${PROJECT_NAME} PRIVATE NUMBA_MLIR_USE_SYCL_MKL=1)
 endif()
+target_compile_options(${PROJECT_NAME} PRIVATE -fno-sycl-id-queries-fit-in-int)
 
 install(TARGETS ${PROJECT_NAME}
         DESTINATION "${MATH_SYCL_RUNTIME_INSTALL_PATH}"

--- a/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
@@ -1999,4 +1999,5 @@ def test_sycl_id_fit_in_int():
     b = 10
 
     func[2**31 + 1,](gpu_arr, b)
-    assert gpu_arr[0] == b
+    _to_host(gpu_arr, arr)
+    assert arr[0] == b

--- a/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
@@ -1984,3 +1984,19 @@ def test_pairwise2():
 
     _to_host(dgpu_res, gpu_res)
     assert_allclose(res, gpu_res, rtol=1e-5)
+
+
+@require_gpu
+def test_sycl_id_fit_in_int():
+    @kernel_cached
+    def func(a, b):
+        i = get_global_id(0)
+        if i == b:
+            a[0] = b
+
+    arr = np.zeros(1).astype(np.float32)
+    gpu_arr = _from_host(arr, buffer="device")
+    b = 10
+
+    func[2**31 + 1,](gpu_arr, b)
+    assert gpu_arr[0] == b

--- a/numba_mlir_gpu_runtime_sycl/CMakeLists.txt
+++ b/numba_mlir_gpu_runtime_sycl/CMakeLists.txt
@@ -35,6 +35,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../numba_mlir_gpu_common
     ${LevelZero_INCLUDE_DIR}
 )
+target_compile_options(${PROJECT_NAME} PRIVATE -fno-sycl-id-queries-fit-in-int)
 
 install(TARGETS ${PROJECT_NAME}
         DESTINATION "${SYCL_RUNTIME_INSTALL_PATH}"


### PR DESCRIPTION
Add no-sycl-id-queries-fit-in-int flag to sycl-related libraries to allow run kernels with indexes outside int32 range
