### PR TITLE
Fix `ChangeLayoutOp` propagation through loops

### DIFF
--- a/mlir/lib/Dialect/numba_util/Dialect.cpp
+++ b/mlir/lib/Dialect/numba_util/Dialect.cpp
@@ -1138,7 +1138,7 @@ struct ChangeLayoutWhileAfter
     }
 
     auto newWhile = rewriter.create<mlir::scf::WhileOp>(
-        loc, op->getResultTypes(), newArgs, nullptr, nullptr);
+        loc, whileOp->getResultTypes(), newArgs, nullptr, nullptr);
 
     auto oldBefore = whileOp.getBeforeBody();
     auto oldAfter = whileOp.getAfterBody();
@@ -1146,6 +1146,8 @@ struct ChangeLayoutWhileAfter
     auto newAfter = newWhile.getAfterBody();
 
     rewriter.setInsertionPointToStart(newBefore);
+
+    assert(newArgs.size() == newBefore->getNumArguments());
     for (auto &&[i, arg] : llvm::enumerate(newBefore->getArguments())) {
       auto oldType = oldBefore->getArgument(i).getType();
       auto newType = arg.getType();

--- a/mlir/test/Dialect/numba_util/canonicalize-change-layout.mlir
+++ b/mlir/test/Dialect/numba_util/canonicalize-change-layout.mlir
@@ -105,3 +105,26 @@ func.func @test_change_layout() -> memref<?xi32> {
   }
   return %0 : memref<?xi32>
 }
+
+// -----
+
+// CHECK-LABEL: func @test_change_layout
+//       CHECK:   %[[RES:.*]] = scf.while
+//       CHECK:   %[[M1:.*]] = "test.test"() : () -> memref<?xi32, strided<[?], offset: ?>>
+//       CHECK:   scf.condition(%{{.*}}) %[[M1]] : memref<?xi32, strided<[?], offset: ?>>
+//       CHECK:   ^bb0(%{{.*}}: memref<?xi32, strided<[?], offset: ?>>):
+//       CHECK:   %[[RES1:.]] = numba_util.change_layout %[[RES]] : memref<?xi32, strided<[?], offset: ?>> to memref<?xi32>
+//       CHECK:   return %[[RES1]]
+func.func @test_change_layout() -> memref<?xi32> {
+  %0 = "test.test"() : () -> memref<?xi32, strided<[?], offset: ?>>
+  %1 = scf.while () : () -> (memref<?xi32>) {
+    %cond = "test.test"() : () -> i1
+    %2 = "test.test"() : () -> memref<?xi32, strided<[?], offset: ?>>
+    %3 = numba_util.change_layout %2 : memref<?xi32, strided<[?], offset: ?>> to memref<?xi32>
+    scf.condition(%cond) %3 : memref<?xi32>
+  } do {
+  ^bb0(%arg2: memref<?xi32>):
+    scf.yield
+  }
+  return %1 : memref<?xi32>
+}

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
@@ -1076,6 +1076,27 @@ def test_np_reduce(dtype):
         assert ir.count("memref.load") == 1, ir
 
 
+def test_propagate_layout_for():
+    def py_func1(a, b):
+        return a
+
+    jit_func1 = njit(py_func1)
+
+    def py_func(n, a):
+        b = a
+        for i in range(n):
+            if i == 5:
+                b = jit_func1(a, b)
+            else:
+                b = a
+        return b
+
+    jit_func = njit(py_func)
+
+    a = np.array([1, 2, 3, 4, 5], dtype=np.int32)
+    assert_equal(py_func(10, a), jit_func(10, a))
+
+
 _indirect_array_call_args = [
     np.arange(12),
     np.arange(12).reshape(3, 4),

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
@@ -1144,6 +1144,32 @@ def test_propagate_layout_while2():
     assert_equal(py_func(10, a, b), jit_func(10, a, b))
 
 
+def test_propagate_layout_while3():
+    def py_func1(a, b):
+        return a
+
+    jit_func1 = njit(py_func1)
+
+    def py_func(n, a):
+        b = a
+        i = 1
+        while True:
+            if i == 5:
+                b = jit_func1(a, b)
+            else:
+                b = a
+            i *= 2
+
+            if i >= n:
+                break
+        return b
+
+    jit_func = njit(py_func)
+
+    a = np.array([1, 2, 3, 4, 5], dtype=np.int32)
+    assert_equal(py_func(10, a), jit_func(10, a))
+
+
 _indirect_array_call_args = [
     np.arange(12),
     np.arange(12).reshape(3, 4),

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
@@ -1120,6 +1120,30 @@ def test_propagate_layout_while1():
     assert_equal(py_func(10, a), jit_func(10, a))
 
 
+def test_propagate_layout_while2():
+    def py_func1(a, b):
+        return a
+
+    jit_func1 = njit(py_func1)
+
+    def py_func(n, a, c):
+        b = c
+        i = 1
+        while i < n:
+            if i == 5:
+                b = jit_func1(a, b)
+            else:
+                b = a
+            i *= 2
+        return b
+
+    jit_func = njit(py_func)
+
+    a = np.array([1, 2, 3, 4, 5], dtype=np.int32)
+    b = np.array([1, 2, 3, 4, 5], dtype=np.int32)[::2]
+    assert_equal(py_func(10, a, b), jit_func(10, a, b))
+
+
 _indirect_array_call_args = [
     np.arange(12),
     np.arange(12).reshape(3, 4),

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
@@ -1097,6 +1097,29 @@ def test_propagate_layout_for():
     assert_equal(py_func(10, a), jit_func(10, a))
 
 
+def test_propagate_layout_while1():
+    def py_func1(a, b):
+        return a
+
+    jit_func1 = njit(py_func1)
+
+    def py_func(n, a):
+        b = a
+        i = 1
+        while i < n:
+            if i == 5:
+                b = jit_func1(a, b)
+            else:
+                b = a
+            i *= 2
+        return b
+
+    jit_func = njit(py_func)
+
+    a = np.array([1, 2, 3, 4, 5], dtype=np.int32)
+    assert_equal(py_func(10, a), jit_func(10, a))
+
+
 _indirect_array_call_args = [
     np.arange(12),
     np.arange(12).reshape(3, 4),


### PR DESCRIPTION
Needed when mixing strided and contigious layouts inside loops. Needed for `dbscan`  WL.