### PR TITLE
Masked vectorize

### DIFF
--- a/mlir/include/numba/Transforms/SCFVectorize.hpp
+++ b/mlir/include/numba/Transforms/SCFVectorize.hpp
@@ -21,6 +21,7 @@ struct SCFVectorizeInfo {
   unsigned dim = 0;
   unsigned factor = 0;
   unsigned count = 0;
+  bool masked = false;
 };
 
 std::optional<SCFVectorizeInfo> getLoopVectorizeInfo(mlir::scf::ParallelOp loop,
@@ -30,6 +31,7 @@ std::optional<SCFVectorizeInfo> getLoopVectorizeInfo(mlir::scf::ParallelOp loop,
 struct SCFVectorizeParams {
   unsigned dim = 0;
   unsigned factor = 0;
+  bool masked = false;
 };
 
 mlir::LogicalResult vectorizeLoop(mlir::OpBuilder &builder,

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
@@ -991,8 +991,8 @@ def test_array_vectorize(arr):
         jit_func = njit(py_func)
         assert_allclose(py_func(arr), jit_func(arr))
         ir = get_print_buffer()
-        assert ir.count("vector.load") > 0, ir
-        assert ir.count("vector.store") > 0, ir
+        assert ir.count("vector.maskedload") > 0, ir
+        assert ir.count("vector.maskedstore") > 0, ir
 
 
 @pytest.mark.parametrize(
@@ -1019,7 +1019,7 @@ def test_array_reduction_vectorize(py_func, arr):
         jit_func = njit(py_func)
         assert_allclose(py_func(arr), jit_func(arr))
         ir = get_print_buffer()
-        assert ir.count("vector.load") > 0, ir
+        assert ir.count("vector.maskedload") > 0, ir
         assert ir.count("vector.reduction") > 0, ir
 
 
@@ -1035,8 +1035,8 @@ def test_prange_vectorize_1d():
         jit_func = njit(py_func)
         assert_allclose(py_func(arr), jit_func(arr))
         ir = get_print_buffer()
-        assert ir.count("vector.load") > 0, ir
-        assert ir.count("vector.store") > 0, ir
+        assert ir.count("vector.maskedload") > 0, ir
+        assert ir.count("vector.maskedstore") > 0, ir
 
 
 @pytest.mark.xfail
@@ -1053,8 +1053,8 @@ def test_prange_vectorize_2d():
         jit_func = njit(py_func)
         assert_allclose(py_func(arr), jit_func(arr))
         ir = get_print_buffer()
-        assert ir.count("vector.load") > 0, ir
-        assert ir.count("vector.store") > 0, ir
+        assert ir.count("vector.maskedload") > 0, ir
+        assert ir.count("vector.maskedstore") > 0, ir
 
 
 def test_copy_fusion():

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToLlvm.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToLlvm.cpp
@@ -32,6 +32,7 @@
 #include <mlir/Dialect/UB/IR/UBOps.h>
 #include <mlir/Dialect/Vector/IR/VectorOps.h>
 #include <mlir/Dialect/Vector/Transforms/LoweringPatterns.h>
+#include <mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h>
 #include <mlir/Dialect/Vector/Transforms/VectorTransforms.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/IRMapping.h>
@@ -1795,7 +1796,14 @@ struct LLVMLoweringPass
     arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
     populateComplexToLLVMConversionPatterns(typeConverter, patterns);
     ub::populateUBToLLVMConversionPatterns(typeConverter, patterns);
-    populateVectorToLLVMConversionPatterns(typeConverter, patterns);
+
+    bool force32BitVectorIndices = false;
+    bool reassociateFPReductions = false;
+    vector::populateVectorMaskMaterializationPatterns(patterns,
+                                                      force32BitVectorIndices);
+    populateVectorToLLVMConversionPatterns(typeConverter, patterns,
+                                           reassociateFPReductions,
+                                           force32BitVectorIndices);
 
     patterns.insert<AllocOpLowering, DeallocOpLowering, LowerRetainOp,
                     LowerWrapAllocPointerOp, LowerGetAllocToken,

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/ParallelToTbb.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/ParallelToTbb.cpp
@@ -393,6 +393,7 @@ static void populateParallelToTbbPipeline(mlir::OpPassManager &pm) {
       std::make_unique<HoistBufferAllocsPass>());
   pm.addNestedPass<mlir::func::FuncOp>(mlir::createCanonicalizerPass());
   pm.addNestedPass<mlir::func::FuncOp>(numba::createSCFVectorizePass());
+  pm.addNestedPass<mlir::func::FuncOp>(mlir::createCSEPass());
   pm.addNestedPass<mlir::func::FuncOp>(mlir::createCanonicalizerPass());
 }
 } // namespace


### PR DESCRIPTION
Genarate masked vector ops where possible to avoid separate loop for cases when when loop size is not divisible by vector factor.