### PR TITLE
Fixes for black-scholes

### DIFF
--- a/benchmarks/benchmarks/npbench/weather_stencils/vadv/numba_mlir.py
+++ b/benchmarks/benchmarks/npbench/weather_stencils/vadv/numba_mlir.py
@@ -22,7 +22,6 @@ class Benchmark(numba_mlir.mlir.benchmarking.BenchmarkBase):
         return get_impl(get_numba_mlir_context())
 
     def initialize(self, preset):
-        self.is_expected_failure = self.is_validate
         preset = parameters[preset]
         return initialize(**preset)
 

--- a/mlir/include/numba/Analysis/AliasAnalysis.hpp
+++ b/mlir/include/numba/Analysis/AliasAnalysis.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <mlir/Analysis/AliasAnalysis.h>
 #include <mlir/Analysis/AliasAnalysis/LocalAliasAnalysis.h>
 
 namespace mlir {
@@ -25,5 +26,12 @@ protected:
   mlir::AliasResult aliasImpl(mlir::Value lhs, mlir::Value rhs) override;
 };
 
+class AliasAnalysis : public mlir::AliasAnalysis {
+public:
+  AliasAnalysis(mlir::Operation *op);
+};
+
 mlir::StringRef getRestrictArgName();
+
+bool isWriter(mlir::Operation &op, llvm::SmallVectorImpl<mlir::Value> &args);
 } // namespace numba

--- a/mlir/include/numba/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/numba/Dialect/ntensor/IR/NTensorOps.td
@@ -642,7 +642,7 @@ def CreateArrayOp : NTensor_OpBase<"create", [AttrSizedOperandSegments, Pure]> {
 }
 
 def FromTensorOp : NTensor_OpBase<"from_tensor",
-    [Pure, SameOperandsShape, SameOperandsElementType]> {
+    [Pure, SameOperandsShape, SameOperandsElementType, ViewLikeOpInterface]> {
   let summary = "converts tensor to ntensor array.";
   let description = [{
     Converts from tensor to ntensor array. Shape and element type must match.
@@ -655,10 +655,14 @@ def FromTensorOp : NTensor_OpBase<"from_tensor",
 
   let hasFolder = 1;
   let hasCanonicalizer = 1;
+
+  let extraClassDeclaration = [{
+      ::mlir::Value getViewSource() { return getTensor(); }
+  }];
 }
 
 def ToTensorOp : NTensor_OpBase<"to_tensor",
-    [SameOperandsShape, SameOperandsElementType]> {
+    [SameOperandsShape, SameOperandsElementType, ViewLikeOpInterface]> {
   let summary = "converts ntensor array to tensor.";
   let description = [{
     Converts from ntensor array to tensor. Shape and element type must match.
@@ -671,6 +675,10 @@ def ToTensorOp : NTensor_OpBase<"to_tensor",
   let assemblyFormat = "$array attr-dict `:` qualified(type($array)) `to` type($result)";
 
   let hasFolder = 1;
+
+  let extraClassDeclaration = [{
+      ::mlir::Value getViewSource() { return getArray(); }
+  }];
 }
 
 def FromMemrefOp : NTensor_OpBase<"from_memref",

--- a/mlir/lib/Analysis/AliasAnalysis.cpp
+++ b/mlir/lib/Analysis/AliasAnalysis.cpp
@@ -88,6 +88,18 @@ llvm::StringRef numba::getRestrictArgName() { return "numba.restrict"; }
 
 bool numba::isWriter(mlir::Operation &op,
                      llvm::SmallVectorImpl<mlir::Value> &args) {
+  // TODO: unhardcode:
+  if (auto generic = mlir::dyn_cast<mlir::linalg::GenericOp>(op)) {
+    bool hasWrite = false;
+    for (auto out : generic.getOutputs()) {
+      if (mlir::isa<mlir::MemRefType>(out.getType())) {
+        args.emplace_back(out);
+        hasWrite = true;
+      }
+    }
+    return hasWrite;
+  }
+
   if (auto func = mlir::dyn_cast<mlir::CallOpInterface>(op)) {
     llvm::append_range(args, func.getArgOperands());
     return true;

--- a/mlir/lib/Conversion/NtensorToLinalg.cpp
+++ b/mlir/lib/Conversion/NtensorToLinalg.cpp
@@ -243,6 +243,9 @@ struct ConvertCastOp : public mlir::OpRewritePattern<numba::ntensor::CastOp> {
   mlir::LogicalResult
   matchAndRewrite(numba::ntensor::CastOp op,
                   mlir::PatternRewriter &rewriter) const override {
+    if (!op->hasAttr(kReadonly))
+      return mlir::failure();
+
     auto src = op.getSource();
     auto srcType = getNTensorType(src);
     if (!srcType)
@@ -711,6 +714,9 @@ struct NtensorAliasAnalysisPass
 
       if (auto create = mlir::dyn_cast<numba::ntensor::CreateArrayOp>(op))
         return create.getResult();
+
+      if (auto cast = mlir::dyn_cast<numba::ntensor::CastOp>(op))
+        return cast.getDest();
 
       return {};
     };

--- a/mlir/lib/Conversion/NtensorToLinalg.cpp
+++ b/mlir/lib/Conversion/NtensorToLinalg.cpp
@@ -4,11 +4,11 @@
 
 #include "numba/Conversion/NtensorToLinalg.hpp"
 
+#include "numba/Analysis/AliasAnalysis.hpp"
 #include "numba/Dialect/ntensor/IR/NTensorOps.hpp"
 #include "numba/Dialect/numba_util/Dialect.hpp"
 #include "numba/Dialect/numba_util/Utils.hpp"
 
-#include <mlir/Analysis/AliasAnalysis.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Linalg/IR/Linalg.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
@@ -707,7 +707,7 @@ struct NtensorAliasAnalysisPass
       if (!hasWriters)
         return nullptr;
 
-      return &getAnalysis<mlir::AliasAnalysis>();
+      return &getAnalysis<numba::AliasAnalysis>();
     }();
 
     auto getTensor = [](mlir::Operation *op) -> mlir::Value {

--- a/mlir/lib/Conversion/NtensorToLinalg.cpp
+++ b/mlir/lib/Conversion/NtensorToLinalg.cpp
@@ -367,6 +367,9 @@ struct ConvertLoadOp : public mlir::OpRewritePattern<numba::ntensor::LoadOp> {
   mlir::LogicalResult
   matchAndRewrite(numba::ntensor::LoadOp op,
                   mlir::PatternRewriter &rewriter) const override {
+    if (!op->hasAttr(kReadonly))
+      return mlir::failure();
+
     auto src = op.getArray();
     auto srcType = getNTensorType(src);
     if (!srcType || op.getType() != srcType.getElementType())
@@ -717,6 +720,9 @@ struct NtensorAliasAnalysisPass
 
       if (auto cast = mlir::dyn_cast<numba::ntensor::CastOp>(op))
         return cast.getDest();
+
+      if (auto load = mlir::dyn_cast<numba::ntensor::LoadOp>(op))
+        return load.getArray();
 
       return {};
     };

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
@@ -2613,3 +2613,76 @@ def test_batchnorm():
     N, W, H, C = 8, 14, 14, 32
     input = rng.random((N, H, W, C), dtype=np.float32)
     assert_allclose(py_func(input), jit_func(input), rtol=1e-4, atol=1e-7)
+
+
+def test_black_scholes_opt():
+    # Black-scholes should be optimized into single loop
+    def initialize(nopt, seed):
+        import numpy as np
+        import numpy.random as default_rng
+
+        dtype: np.dtype = np.float32
+        S0L = dtype(10.0)
+        S0H = dtype(50.0)
+        XL = dtype(10.0)
+        XH = dtype(50.0)
+        TL = dtype(1.0)
+        TH = dtype(2.0)
+        RISK_FREE = dtype(0.1)
+        VOLATILITY = dtype(0.2)
+
+        default_rng.seed(seed)
+        price = default_rng.uniform(S0L, S0H, nopt).astype(dtype)
+        strike = default_rng.uniform(XL, XH, nopt).astype(dtype)
+        t = default_rng.uniform(TL, TH, nopt).astype(dtype)
+        rate = RISK_FREE
+        volatility = VOLATILITY
+        call = np.zeros(nopt, dtype=dtype)
+        put = -np.ones(nopt, dtype=dtype)
+
+        return (price, strike, t, rate, volatility, call, put)
+
+    @vectorize(nopython=True)
+    def _nberf(x):
+        return math.erf(x)
+
+    def black_scholes(price, strike, t, rate, volatility, call, put):
+        mr = -rate
+        sig_sig_two = volatility * volatility * 2
+
+        P = price
+        S = strike
+        T = t
+
+        a = np.log(P / S)
+        b = T * mr
+
+        z = T * sig_sig_two
+        c = 0.25 * z
+        y = 1.0 / np.sqrt(z)
+
+        w1 = (a - b + c) * y
+        w2 = (a - b - c) * y
+
+        d1 = 0.5 + 0.5 * _nberf(w1)
+        d2 = 0.5 + 0.5 * _nberf(w2)
+
+        Se = np.exp(b) * S
+
+        r = P * d1 - Se * d2
+        call[:] = r  # temporary `r` is necessary for faster `put` computation
+        put[:] = r - P + Se
+
+    black_scholes_jit = njit(black_scholes)
+
+    args1 = initialize(524288, 777777)
+    args2 = initialize(524288, 777777)
+    black_scholes(*args1)
+
+    with print_pass_ir([], ["PostLinalgOptPass"]):
+        black_scholes_jit(*args2)
+        assert_allclose(args1[-1], args2[-1], atol=0.001)
+        assert_allclose(args1[-2], args2[-2], atol=0.001)
+
+        ir = get_print_buffer()
+        assert ir.count("scf.parallel") == 1, ir

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
@@ -2615,6 +2615,21 @@ def test_batchnorm():
     assert_allclose(py_func(input), jit_func(input), rtol=1e-4, atol=1e-7)
 
 
+def test_generic_write():
+    def py_func(a, b):
+        e = b[1:]
+        c = a + b
+        e[:] = c[1:]
+        d = a - b
+        return c, d
+
+    jit_func = njit(py_func)
+
+    a = np.arange(12)
+    b = np.arange(1, 13)
+    assert_equal(py_func(a.copy(), b.copy()), jit_func(a.copy(), b.copy()))
+
+
 def test_black_scholes_opt():
     # Black-scholes should be optimized into single loop
     def initialize(nopt, seed):

--- a/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numpy.py
@@ -2615,12 +2615,27 @@ def test_batchnorm():
     assert_allclose(py_func(input), jit_func(input), rtol=1e-4, atol=1e-7)
 
 
-def test_generic_write():
+def test_generic_write1():
     def py_func(a, b):
         e = b[1:]
         c = a + b
         e[:] = c[1:]
         d = a - b
+        return c, d
+
+    jit_func = njit(py_func)
+
+    a = np.arange(12)
+    b = np.arange(1, 13)
+    assert_equal(py_func(a.copy(), b.copy()), jit_func(a.copy(), b.copy()))
+
+
+def test_generic_write2():
+    def py_func(a, b):
+        e = b[1:]
+        c = a + b
+        e[:] = c[1:]
+        d = a + b
         return c, d
 
     jit_func = njit(py_func)

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -3135,6 +3135,9 @@ static const constexpr llvm::StringLiteral
 
 static bool defaultControlFusionFn(mlir::OpOperand *fusedOperand) {
   assert(fusedOperand);
+  if (llvm::hasNItemsOrMore(fusedOperand->get().getUses(), 2))
+    return false;
+
   if (auto generic =
           mlir::dyn_cast<mlir::linalg::GenericOp>(fusedOperand->getOwner())) {
     // Mixed generics fusion


### PR DESCRIPTION
* Limit linalg fusion to single user to avoid loops duplication
* Check for aliases when converting `ntensor.cast` to `tensor.cast`
* Add fusion hen multiple `linalg.generic` uses same argument