### PR TITLE
Add native module cleanup

### DIFF
--- a/mlir/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/mlir/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -355,7 +355,7 @@ void numba::ExecutionEngine::releaseModule(ModuleHandle handle) {
   assert(handle);
   auto dylib = static_cast<llvm::orc::JITDylib *>(handle);
   llvm::cantFail(jit->deinitialize(*dylib));
-  dylib->Release();
+  llvm::cantFail(jit->getExecutionSession().removeJITDylib(*dylib));
 }
 
 llvm::Expected<void *>

--- a/numba_mlir_gpu_runtime_sycl/lib/GpuRuntime.cpp
+++ b/numba_mlir_gpu_runtime_sycl/lib/GpuRuntime.cpp
@@ -136,7 +136,6 @@ public:
     assert(module);
     assert(name);
     return getGPUKernel(module, name);
-    ;
   }
 
   static void destroyKernel(GPUKernel *kernel) {


### PR DESCRIPTION
* Call dtors and cleanup native module when Numba library object is destroyed
* Fix ownership issues in SYCL runtime
