### PR TITLE
Replace_parfors offload fixes 

### DIFF
--- a/numba_mlir/numba_mlir/mlir/__init__.py
+++ b/numba_mlir/numba_mlir/mlir/__init__.py
@@ -5,4 +5,5 @@
 from . import array_type
 from . import dpctl_interop
 from .builtin import funcs
+from .dpnp import funcs
 from .numpy import funcs, overloads

--- a/numba_mlir/numba_mlir/mlir/dpnp/__init__.py
+++ b/numba_mlir/numba_mlir/mlir/dpnp/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/numba_mlir/numba_mlir/mlir/dpnp/funcs.py
+++ b/numba_mlir/numba_mlir/mlir/dpnp/funcs.py
@@ -24,4 +24,25 @@ if _dnnp_available:
     ):
         return _init_impl(builder, shape, dtype)
 
-    register_func("dpnp.sin", dpnp.sin)(numpy_funcs.sin_impl)
+    def _gen_unary_ops():
+        ops = [
+            "sqrt",
+            "square",
+            "log",
+            "sin",
+            "cos",
+            "exp",
+            "tanh",
+            "abs",
+            "negative",
+            # "positive",
+        ]
+        for op_name in ops:
+            fn_name = "dpnp." + op_name
+            func = getattr(dpnp, op_name)
+            impl_name = op_name + "_impl"
+            impl = getattr(numpy_funcs, impl_name)
+            register_func(op_name, func)(impl)
+
+    _gen_unary_ops()
+    del _gen_unary_ops

--- a/numba_mlir/numba_mlir/mlir/dpnp/funcs.py
+++ b/numba_mlir/numba_mlir/mlir/dpnp/funcs.py
@@ -14,6 +14,14 @@ except ImportError:
 if _dnnp_available:
     from ..numpy import funcs as numpy_funcs
 
+    _init_impl = numpy_funcs._init_impl
+
     register_func = numpy_funcs.register_func
 
-    register_func("dpnp.empty", dpnp.empty)(numpy_funcs.empty_impl)
+    @register_func("dpnp.empty", dpnp.empty)
+    def empty_impl(
+        builder, shape, dtype=None, layout="C", device=None, usm_type="device"
+    ):
+        return _init_impl(builder, shape, dtype)
+
+    register_func("dpnp.sin", dpnp.sin)(numpy_funcs.sin_impl)

--- a/numba_mlir/numba_mlir/mlir/dpnp/funcs.py
+++ b/numba_mlir/numba_mlir/mlir/dpnp/funcs.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+try:
+    import dpnp
+
+    _dnnp_available = True
+except ImportError:
+    _dnnp_available = False
+
+
+if _dnnp_available:
+    from ..numpy import funcs as numpy_funcs
+
+    register_func = numpy_funcs.register_func
+
+    register_func("dpnp.empty", dpnp.empty)(numpy_funcs.empty_impl)

--- a/numba_mlir/numba_mlir/mlir/gpu_runtime.py
+++ b/numba_mlir/numba_mlir/mlir/gpu_runtime.py
@@ -52,6 +52,7 @@ if IS_GPU_RUNTIME_AVAILABLE:
             mlir_func_name("get_local_size"),
             mlir_func_name("kernel_barrier"),
             mlir_func_name("kernel_mem_fence"),
+            "gpuxDuplicateQueue",
         ]
 
         from itertools import product

--- a/numba_mlir/numba_mlir/mlir/numpy/funcs.py
+++ b/numba_mlir/numba_mlir/mlir/numpy/funcs.py
@@ -521,7 +521,7 @@ del _gen_binary_ops
 
 
 @register_func("numpy.clip", numpy.clip, out="out")
-def empty_impl(builder, a, a_min, a_max):
+def clip_impl(builder, a, a_min, a_max):
     init_type = _select_float_type(builder, a, a_min, a_max)
 
     def body(a, a_min, a_max, _):

--- a/numba_mlir_gpu_runtime_sycl/lib/GpuRuntime.cpp
+++ b/numba_mlir_gpu_runtime_sycl/lib/GpuRuntime.cpp
@@ -425,3 +425,13 @@ gpuxSuggestBlockSize(void *stream, void *kernel, const uint32_t *gridSize,
                                        gridSize, blockSize, numDims);
   });
 }
+
+// TODO: not sure it belongs here
+extern "C" NUMBA_MLIR_GPU_RUNTIME_SYCL_EXPORT void *
+gpuxDuplicateQueue(void *queue) {
+  LOG_FUNC();
+  return catchAll([&]() {
+    auto *q = static_cast<sycl::queue *>(queue);
+    return new sycl::queue(*q);
+  });
+}


### PR DESCRIPTION
* `dpnp.empty` support
* Some dpnp ufuncs support
* Properly set queue on returned GPU array