### PR TITLE
Subview lowering refactoring

### DIFF
--- a/mlir/include/numba/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/numba/Dialect/ntensor/IR/NTensorOps.td
@@ -359,13 +359,16 @@ def SubviewOp : NTensor_OpWithOffsetSizesAndStrides<"subview", [
       ::mlir::ArrayRef<::mlir::OpFoldResult> staticSizes,
       ::mlir::ArrayRef<::mlir::OpFoldResult> staticStrides);
 
-    /// A rank-reducing result type can be inferred from the desired result
-    /// shape. Only the layout map is inferred.
-    ///
-    /// Note: The result shape cannot be inferred with just the result rank and
-    /// and the desired sizes. In case there are more "ones" among the sizes
-    /// than the difference in source/result rank, it is not clear which dims of
-    /// size one should be dropped.
+    static NTensorType inferRankReducedResultType(unsigned resultRank,
+                                                  NTensorType sourceType,
+                                                  ::mlir::ArrayRef<int64_t> staticOffsets,
+                                                  ::mlir::ArrayRef<int64_t> staticSizes,
+                                                  ::mlir::ArrayRef<int64_t> staticStrides);
+    static NTensorType inferRankReducedResultType(unsigned resultRank,
+                                                  NTensorType sourceType,
+                                                  ::mlir::ArrayRef<::mlir::OpFoldResult> staticOffsets,
+                                                  ::mlir::ArrayRef<::mlir::OpFoldResult> staticSizes,
+                                                  ::mlir::ArrayRef<::mlir::OpFoldResult> staticStrides);
     static NTensorType inferRankReducedResultType(::mlir::ArrayRef<int64_t> resultShape,
                                                   NTensorType sourceType,
                                                   ::mlir::ArrayRef<int64_t> staticOffsets,

--- a/mlir/lib/Conversion/NtensorToLinalg.cpp
+++ b/mlir/lib/Conversion/NtensorToLinalg.cpp
@@ -51,7 +51,7 @@ struct ConvertCreateOp
       return mlir::failure();
 
     auto results = numba::util::wrapEnvRegion(
-        rewriter, op->getLoc(), dstType.getEnvironment(), dstType,
+        rewriter, op.getLoc(), dstType.getEnvironment(), dstType,
         [&](mlir::OpBuilder &builder, mlir::Location loc) {
           auto tensorType = toTensorType(dstType);
           mlir::Value result = builder.create<mlir::tensor::EmptyOp>(

--- a/mlir/lib/Transforms/MakeSignless.cpp
+++ b/mlir/lib/Transforms/MakeSignless.cpp
@@ -169,6 +169,18 @@ struct ConvertSubview
   }
 };
 
+struct ConvertCopy : public mlir::OpConversionPattern<mlir::memref::CopyOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::memref::CopyOp op, OpAdaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<mlir::memref::CopyOp>(op, adaptor.getSource(),
+                                                      adaptor.getTarget());
+    return mlir::success();
+  }
+};
+
 struct ConvertExtractMetadata
     : public mlir::OpConversionPattern<mlir::memref::ExtractStridedMetadataOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -450,7 +462,7 @@ void numba::populateMakeSignlessRewritesAndTarget(
       numba::util::ChangeLayoutOp, mlir::bufferization::ToMemrefOp,
       mlir::bufferization::ToTensorOp, mlir::memref::AllocOp,
       mlir::memref::AllocaOp, mlir::memref::DeallocOp, mlir::memref::CastOp,
-      mlir::memref::SubViewOp, mlir::tensor::EmptyOp,
+      mlir::memref::SubViewOp, mlir::memref::CopyOp, mlir::tensor::EmptyOp,
       mlir::memref::ExtractStridedMetadataOp, mlir::tensor::FromElementsOp,
       mlir::tensor::ExpandShapeOp, mlir::tensor::ReshapeOp,
       mlir::tensor::ExtractSliceOp, mlir::tensor::InsertSliceOp,
@@ -461,11 +473,11 @@ void numba::populateMakeSignlessRewritesAndTarget(
   patterns.insert<
       ConvertChangeLayout, ConvertToMemref, ConvertToTensor,
       ConvertAlloc<mlir::memref::AllocOp>, ConvertAlloc<mlir::memref::AllocaOp>,
-      ConvertDealloc, ConvertCastOp, ConvertSubview, ConvertExtractMetadata,
-      ConvertTensorEmpty, ConvertTensorFromElements, ConvertTensorExpandShape,
-      ConvertTensorReshape, ConvertTensorExtractSlice, ConvertTensorInserSlice,
-      ConvertLinalgFill, ConvertLinalgGeneric, ConvertLinalgYield,
-      ConvertUtilReshape>(converter, patterns.getContext());
+      ConvertDealloc, ConvertCastOp, ConvertSubview, ConvertCopy,
+      ConvertExtractMetadata, ConvertTensorEmpty, ConvertTensorFromElements,
+      ConvertTensorExpandShape, ConvertTensorReshape, ConvertTensorExtractSlice,
+      ConvertTensorInserSlice, ConvertLinalgFill, ConvertLinalgGeneric,
+      ConvertLinalgYield, ConvertUtilReshape>(converter, patterns.getContext());
 }
 
 namespace {

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/PyLinalgResolver.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/PyLinalgResolver.cpp
@@ -710,11 +710,11 @@ static py::object broadcastImpl(py::capsule context, py::tuple args,
 
   py::tuple ret(results.size());
   for (auto &&[i, res] : llvm::enumerate(results)) {
-    auto srcType = res.getType().cast<mlir::ShapedType>();
-    auto dstType = mlir::RankedTensorType::get(srcType.getShape(),
-                                               srcType.getElementType());
     if (rank >= 0) {
-      res = builder.create<numba::ntensor::ToTensorOp>(loc, dstType, res);
+      auto srcType = mlir::cast<mlir::ShapedType>(res.getType());
+      auto dstType = mlir::RankedTensorType::get(srcType.getShape(),
+                                                 srcType.getElementType());
+      res = doCast(builder, loc, res, dstType);
     } else {
       res = builder.create<numba::ntensor::LoadOp>(loc, res);
     }

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/PyLinalgResolver.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/PyLinalgResolver.cpp
@@ -1295,11 +1295,11 @@ static py::object subviewImpl(py::capsule context, py::handle src,
   auto loc = ctx.loc;
 
   auto unwrapVal = [&](py::handle obj) {
-    return toTensor(loc, builder, ctx.context.unwrapVal(loc, builder, obj));
+    return toNTensor(loc, builder, ctx.context.unwrapVal(loc, builder, obj));
   };
 
   auto srcVal = unwrapVal(src);
-  auto srcType = srcVal.getType().cast<mlir::RankedTensorType>();
+  auto srcType = mlir::cast<numba::ntensor::NTensorType>(srcVal.getType());
 
   auto indexType = builder.getIndexType();
   auto indexCast = [&](mlir::Value val) -> mlir::OpFoldResult {
@@ -1325,7 +1325,7 @@ static py::object subviewImpl(py::capsule context, py::handle src,
 
     auto val = input.front().get<mlir::Value>();
     ValsArray ret;
-    if (auto tupleType = val.getType().dyn_cast<mlir::TupleType>()) {
+    if (auto tupleType = mlir::dyn_cast<mlir::TupleType>(val.getType())) {
       ret.resize(tupleType.size());
       for (auto i : llvm::seq(size_t(0), tupleType.size())) {
         auto ind = builder.create<mlir::arith::ConstantIndexOp>(loc, i);
@@ -1344,7 +1344,7 @@ static py::object subviewImpl(py::capsule context, py::handle src,
     if (sizes.is_none()) {
       ValsArray ret(offsetVals.size());
       for (auto i : llvm::seq(size_t(0), ret.size())) {
-        auto dim = builder.createOrFold<mlir::tensor::DimOp>(
+        auto dim = builder.createOrFold<numba::ntensor::DimOp>(
             loc, srcVal, static_cast<int64_t>(i));
         auto offset = [&]() -> mlir::Value {
           auto off = offsetVals[i];
@@ -1372,25 +1372,25 @@ static py::object subviewImpl(py::capsule context, py::handle src,
       return unpackValues(strides);
     }
   }();
-  auto viewType = [&]() -> mlir::RankedTensorType {
+  auto viewType = [&]() -> numba::ntensor::NTensorType {
     if (rank.is_none()) {
-      return mlir::tensor::ExtractSliceOp::inferResultType(srcType, offsetVals,
-                                                           sizeVals, strideVals)
-          .cast<mlir::RankedTensorType>();
+      return mlir::cast<numba::ntensor::NTensorType>(
+          numba::ntensor::SubviewOp::inferResultType(srcType, offsetVals,
+                                                     sizeVals, strideVals));
     } else {
       auto rankVal = rank.cast<unsigned>();
-      return mlir::tensor::ExtractSliceOp::inferCanonicalRankReducedResultType(
-                 rankVal, srcType, offsetVals, sizeVals, strideVals)
-          .cast<mlir::RankedTensorType>();
+      return mlir::cast<numba::ntensor::NTensorType>(
+          numba::ntensor::SubviewOp::inferRankReducedResultType(
+              rankVal, srcType, offsetVals, sizeVals, strideVals));
     }
   }();
-  auto view = builder.createOrFold<mlir::tensor::ExtractSliceOp>(
+  auto view = builder.createOrFold<numba::ntensor::SubviewOp>(
       loc, viewType, srcVal, offsetVals, sizeVals, strideVals);
 
-  auto resType = view.getType().cast<mlir::ShapedType>();
+  auto resType = mlir::cast<mlir::ShapedType>(view.getType());
   auto resDynamicType = resType.clone(getDynShape(resType.getRank()));
   if (resDynamicType != resType)
-    view = builder.create<mlir::tensor::CastOp>(loc, resDynamicType, view);
+    view = builder.create<numba::ntensor::CastOp>(loc, resDynamicType, view);
   return ctx.context.createVar(context, view);
 }
 


### PR DESCRIPTION
* Add `ntensor.subview` `inferRankReducedResultType` functions which take rank as int
* `MakeSignless` `memref.copy` support
* Use `ntensor.subview` instead of `tensor.extract_slice` in linalg resolver