### PR TITLE
Rework how gpu allocations are handled

### DIFF
--- a/mlir/include/numba/Conversion/GpuToGpuRuntime.hpp
+++ b/mlir/include/numba/Conversion/GpuToGpuRuntime.hpp
@@ -57,4 +57,6 @@ std::unique_ptr<mlir::Pass> createSortParallelLoopsForGPU();
 
 std::unique_ptr<mlir::Pass> createGpuDecomposeMemrefsPass();
 
+std::unique_ptr<mlir::Pass> createCreateGPUAllocPass();
+
 } // namespace gpu_runtime

--- a/mlir/include/numba/Dialect/gpu_runtime/IR/GpuRuntimeOps.hpp
+++ b/mlir/include/numba/Dialect/gpu_runtime/IR/GpuRuntimeOps.hpp
@@ -33,6 +33,7 @@ mlir::StringRef getFenceFlagsAttrName();
 mlir::StringRef getFp64TruncateAttrName();
 mlir::StringRef getUse64BitIndexAttrName();
 mlir::StringRef getDeviceFuncAttrName();
+mlir::StringRef getHostAllocAttrName();
 
 enum class FenceFlags : int64_t {
   local = 1,

--- a/mlir/include/numba/Dialect/gpu_runtime/IR/GpuRuntimeOps.hpp
+++ b/mlir/include/numba/Dialect/gpu_runtime/IR/GpuRuntimeOps.hpp
@@ -16,6 +16,8 @@
 
 #include <mlir/Dialect/GPU/IR/GPUDialect.h>
 
+#include "numba/Dialect/numba_util/Dialect.hpp"
+
 #include "numba/Dialect/gpu_runtime/IR/GpuRuntimeOpsDialect.h.inc"
 
 #define GET_TYPEDEF_CLASSES

--- a/mlir/include/numba/Dialect/gpu_runtime/IR/GpuRuntimeOps.td
+++ b/mlir/include/numba/Dialect/gpu_runtime/IR/GpuRuntimeOps.td
@@ -22,6 +22,11 @@ def GpuRuntime_Dialect : Dialect {
     }];
   let cppNamespace = "::gpu_runtime";
 
+  let dependentDialects = [
+    "::numba::util::NumbaUtilDialect"
+  ];
+
+  let hasCanonicalizer = 1;
   let hasConstantMaterializer = 1;
   let useDefaultAttributePrinterParser = 1;
   let useDefaultTypePrinterParser = 1;

--- a/mlir/include/numba/Dialect/gpu_runtime/IR/GpuRuntimeOps.td
+++ b/mlir/include/numba/Dialect/gpu_runtime/IR/GpuRuntimeOps.td
@@ -49,6 +49,7 @@ def GPURegionDescAttr
     : GpuRuntime_Attr<"GPURegionDesc", "region_desc"> {
   let parameters = (ins
     "::mlir::StringAttr":$device,
+    "::mlir::StringAttr":$usm_type, // TODO: enum
     "int16_t":$spirv_major_version,
     "int16_t":$spirv_minor_version,
     "bool":$has_fp16,
@@ -58,13 +59,15 @@ def GPURegionDescAttr
   let builders = [
     AttrBuilderWithInferredContext<(ins "::mlir::MLIRContext *":$context,
                                         "::mlir::StringRef":$device,
+                                        "::mlir::StringRef":$usm_type,
                                         "int16_t":$spirv_major_version,
                                         "int16_t":$spirv_minor_version,
                                         "bool":$has_fp16,
                                         "bool":$has_fp64), [{
       mlir::OpBuilder builder(context);
       auto devAttr = builder.getStringAttr(device);
-      return $_get(context, devAttr, spirv_major_version, spirv_minor_version, has_fp16, has_fp64);
+      auto usmAttr = builder.getStringAttr(usm_type);
+      return $_get(context, devAttr, usmAttr, spirv_major_version, spirv_minor_version, has_fp16, has_fp64);
     }]>
   ];
 }

--- a/mlir/include/numba/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/numba/Dialect/ntensor/IR/NTensorOps.td
@@ -642,6 +642,8 @@ def CreateArrayOp : NTensor_OpBase<"create", [AttrSizedOperandSegments, Pure]> {
     // Asserts that the shape is dynamic at that `idx`.
     ::mlir::Value getDynamicSize(unsigned idx);
   }];
+
+  let hasCanonicalizer = 1;
 }
 
 def FromTensorOp : NTensor_OpBase<"from_tensor",

--- a/mlir/include/numba/Dialect/numba_util/Dialect.hpp
+++ b/mlir/include/numba/Dialect/numba_util/Dialect.hpp
@@ -28,6 +28,18 @@
 
 namespace numba {
 namespace util {
+class DialectEnvInterface
+    : public mlir::DialectInterface::Base<DialectEnvInterface> {
+public:
+  DialectEnvInterface(mlir::Dialect *dialect) : Base(dialect) {}
+
+  virtual std::optional<mlir::Attribute>
+  mergeEnvAttrs(mlir::Attribute env1, mlir::Attribute env2) = 0;
+};
+
+std::optional<mlir::Attribute> mergeEnvAttrs(mlir::Attribute env1,
+                                             mlir::Attribute env2);
+
 namespace attributes {
 llvm::StringRef getFastmathName();
 llvm::StringRef getJumpMarkersName();

--- a/mlir/lib/Conversion/GpuRuntimeToLlvm.cpp
+++ b/mlir/lib/Conversion/GpuRuntimeToLlvm.cpp
@@ -675,6 +675,8 @@ private:
       memType = numba::GpuAllocType::Shared;
     } else if (isLocal) {
       memType = numba::GpuAllocType::Local;
+    } else if (op->hasAttr(gpu_runtime::getHostAllocAttrName())) {
+      memType = numba::GpuAllocType::Host;
     }
 
     auto typeVar = rewriter.create<mlir::LLVM::ConstantOp>(

--- a/mlir/lib/Conversion/GpuToGpuRuntime.cpp
+++ b/mlir/lib/Conversion/GpuToGpuRuntime.cpp
@@ -1462,10 +1462,12 @@ struct ExpandAllocOp : public mlir::OpRewritePattern<mlir::gpu::AllocOp> {
     auto hostShared = op.getHostShared();
     mlir::Type token =
         op.getAsyncToken() ? op.getAsyncToken().getType() : nullptr;
-    rewriter.replaceOpWithNewOp<gpu_runtime::GPUAllocOp>(
-        op, op.getType(), token, op.getAsyncDependencies(), *queue,
+    auto newOp = rewriter.create<gpu_runtime::GPUAllocOp>(
+        op.getLoc(), op.getType(), token, op.getAsyncDependencies(), *queue,
         op.getDynamicSizes(), op.getSymbolOperands(), hostShared);
 
+    newOp->setAttrs(op->getDiscardableAttrs());
+    rewriter.replaceOp(op, newOp.getResults());
     return mlir::success();
   }
 };

--- a/mlir/lib/Dialect/gpu_runtime/IR/GpuRuntimeOps.cpp
+++ b/mlir/lib/Dialect/gpu_runtime/IR/GpuRuntimeOps.cpp
@@ -223,6 +223,9 @@ mlir::StringRef getUse64BitIndexAttrName() {
 }
 
 mlir::StringRef getDeviceFuncAttrName() { return "gpu_runtime.device_func"; }
+
+llvm::StringRef getHostAllocAttrName() { return "gpu_runtime.host_alloc"; }
+
 } // namespace gpu_runtime
 
 // TODO: unify with upstream

--- a/mlir/lib/Dialect/gpu_runtime/IR/GpuRuntimeOps.cpp
+++ b/mlir/lib/Dialect/gpu_runtime/IR/GpuRuntimeOps.cpp
@@ -35,6 +35,46 @@ struct GpuRuntimeInlinerInterface : public mlir::DialectInlinerInterface {
     return true;
   }
 };
+
+struct GpuRuntimeMergeEnvInterface : public numba::util::DialectEnvInterface {
+  using DialectEnvInterface::DialectEnvInterface;
+
+  virtual std::optional<mlir::Attribute>
+  mergeEnvAttrs(mlir::Attribute env1, mlir::Attribute env2) override {
+    auto gpuEnv1 = mlir::dyn_cast<gpu_runtime::GPURegionDescAttr>(env1);
+    if (!gpuEnv1)
+      return std::nullopt;
+
+    auto gpuEnv2 = mlir::dyn_cast<gpu_runtime::GPURegionDescAttr>(env2);
+    if (!gpuEnv2)
+      return std::nullopt;
+
+    // TODO: keep in sync with definition
+    if (gpuEnv1.getDevice() != gpuEnv2.getDevice() ||
+        gpuEnv1.getSpirvMajorVersion() != gpuEnv2.getSpirvMajorVersion() ||
+        gpuEnv1.getSpirvMinorVersion() != gpuEnv2.getSpirvMinorVersion() ||
+        gpuEnv1.getHasFp16() != gpuEnv2.getHasFp16() ||
+        gpuEnv1.getHasFp64() != gpuEnv2.getHasFp64())
+      return std::nullopt;
+
+    auto ctx = env1.getContext();
+    auto device = mlir::StringAttr::get(ctx, "device");
+    if (gpuEnv1.getUsmType() == device)
+      return gpuEnv1;
+
+    if (gpuEnv2.getUsmType() == device)
+      return gpuEnv2;
+
+    auto shared = mlir::StringAttr::get(ctx, "shared");
+    if (gpuEnv1.getUsmType() == shared)
+      return gpuEnv1;
+
+    if (gpuEnv2.getUsmType() == shared)
+      return gpuEnv2;
+
+    return std::nullopt;
+  }
+};
 } // namespace
 
 namespace gpu_runtime {
@@ -54,7 +94,7 @@ void GpuRuntimeDialect::initialize() {
 #include "numba/Dialect/gpu_runtime/IR/GpuRuntimeOpsAttributes.cpp.inc"
       >();
 
-  addInterfaces<GpuRuntimeInlinerInterface>();
+  addInterfaces<GpuRuntimeInlinerInterface, GpuRuntimeMergeEnvInterface>();
 }
 
 mlir::Operation *

--- a/mlir/lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
+++ b/mlir/lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
@@ -5,6 +5,7 @@
 #include "numba/Dialect/ntensor/Transforms/PropagateEnvironment.hpp"
 
 #include "numba/Dialect/ntensor/IR/NTensorOps.hpp"
+#include "numba/Dialect/numba_util/Dialect.hpp"
 
 #include <llvm/Support/Debug.h>
 #include <mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h>
@@ -93,7 +94,8 @@ public:
     if (!rhs.getEnv())
       return lhs;
 
-    return lhs.env == rhs.env ? lhs : getInvalid(lhs.env, rhs.env);
+    auto res = numba::util::mergeEnvAttrs(lhs.getEnv(), rhs.getEnv());
+    return res ? EnvValue(*res) : getInvalid(lhs.env, rhs.env);
   }
 
   bool operator==(const EnvValue &rhs) const { return env == rhs.env; }

--- a/mlir/lib/Dialect/numba_util/Dialect.cpp
+++ b/mlir/lib/Dialect/numba_util/Dialect.cpp
@@ -2570,6 +2570,29 @@ void GetAllocTokenOp::getCanonicalizationPatterns(
     mlir::RewritePatternSet &results, mlir::MLIRContext *context) {
   results.insert<PropagateAllocTokenCasts>(context);
 }
+
+std::optional<mlir::Attribute> mergeEnvAttrs(mlir::Attribute env1,
+                                             mlir::Attribute env2) {
+  if (env1 == env2)
+    return env1;
+
+  if (!env1 || !env2)
+    return std::nullopt;
+
+  if (&env1.getDialect() != &env2.getDialect())
+    return std::nullopt;
+
+  auto *mergeInterface =
+      mlir::dyn_cast<DialectEnvInterface>(&env1.getDialect());
+  if (!mergeInterface)
+    return std::nullopt;
+
+  auto res = mergeInterface->mergeEnvAttrs(env1, env2);
+  assert(res == mergeInterface->mergeEnvAttrs(env2, env1) &&
+         "mergeEnvAttrs must be symmetrical");
+  return res;
+}
+
 } // namespace util
 } // namespace numba
 

--- a/mlir/test/Transforms/InsertGpuAllocs/add-gpu-alloc.mlir
+++ b/mlir/test/Transforms/InsertGpuAllocs/add-gpu-alloc.mlir
@@ -86,18 +86,18 @@ func.func @addt(%arg0: memref<2x5xf32>, %arg1: memref<2x5xf32>) -> memref<2x5xf3
   %c2 = arith.constant 2 : index
   %c1 = arith.constant 1 : index
   %c5 = arith.constant 5 : index
-  // CHECK: %[[RES0:.*]] = numba_util.env_region #gpu_runtime.region_desc<device = "test", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> -> memref<2x5xf32>
+  // CHECK: %[[RES0:.*]] = numba_util.env_region #gpu_runtime.region_desc<device = "test", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> -> memref<2x5xf32>
   // CHECK: %[[MEMREF0:.*]] = gpu.alloc host_shared () : memref<2x5xf32>
   // CHECK: memref.copy %[[ARG2]], %[[MEMREF0]] : memref<2x5xf32> to memref<2x5xf32>
   // CHECK: numba_util.env_region_yield %[[MEMREF0]] : memref<2x5xf32>
 
-  // CHECK: %[[RES1:.*]] = numba_util.env_region #gpu_runtime.region_desc<device = "test", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> -> memref<2x5xf32>
+  // CHECK: %[[RES1:.*]] = numba_util.env_region #gpu_runtime.region_desc<device = "test", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> -> memref<2x5xf32>
   // CHECK: %[[MEMREF1:.*]] = gpu.alloc host_shared () : memref<2x5xf32>
   // CHECK: memref.copy %[[ARG1]], %[[MEMREF1]] : memref<2x5xf32> to memref<2x5xf32>
   // CHECK: numba_util.env_region_yield %[[MEMREF1]] : memref<2x5xf32>
 
   %0 = memref.alloc() {alignment = 128 : i64} : memref<2x5xf32>
-  // CHECK: %[[RES2:.*]] = numba_util.env_region #gpu_runtime.region_desc<device = "test", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> -> memref<2x5xf32>
+  // CHECK: %[[RES2:.*]] = numba_util.env_region #gpu_runtime.region_desc<device = "test", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> -> memref<2x5xf32>
   // CHECK:  %[[MEMREF2:.*]] = gpu.alloc host_shared () : memref<2x5xf32>
   // CHECK: numba_util.env_region_yield %[[MEMREF2]] : memref<2x5xf32>
 
@@ -105,7 +105,7 @@ func.func @addt(%arg0: memref<2x5xf32>, %arg1: memref<2x5xf32>) -> memref<2x5xf3
   %1 = affine.apply affine_map<(d0)[s0, s1] -> ((d0 - s0) ceildiv s1)>(%c2)[%c0, %c1]
   %2 = affine.apply affine_map<(d0)[s0, s1] -> ((d0 - s0) ceildiv s1)>(%c5)[%c0, %c1]
 
-  numba_util.env_region #gpu_runtime.region_desc<device = "test", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> {
+  numba_util.env_region #gpu_runtime.region_desc<device = "test", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> {
     gpu.launch blocks(%arg2, %arg3, %arg4) in (%arg8 = %1, %arg9 = %2, %arg10 = %c1_0) threads(%arg5, %arg6, %arg7) in (%arg11 = %c1_0, %arg12 = %c1_0, %arg13 = %c1_0) {
       // CHECK: %[[IDX1:.*]] = affine.apply #map1(%{{.*}})[%{{.*}}, %{{.*}}]
       %3 = affine.apply affine_map<(d0)[s0, s1] -> (d0 * s0 + s1)>(%arg2)[%c1, %c0]

--- a/mlir/test/Transforms/gpu-to-gpux.mlir
+++ b/mlir/test/Transforms/gpu-to-gpux.mlir
@@ -34,15 +34,15 @@ func.func @region() -> (memref<10xf32>, memref<11xf32>, memref<12xf32>){
 // CHECK: %[[S3:.*]] = gpu_runtime.create_gpu_queue, "test2"
 // CHECK: %[[A1:.*]] = gpu_runtime.alloc %[[S1]] () : memref<10xf32>
   %0 = gpu.alloc () : memref<10xf32>
-// CHECK: %[[R1:.*]] = numba_util.env_region #gpu_runtime.region_desc<device = "test1", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> -> memref<11xf32> {
-  %1 = numba_util.env_region #gpu_runtime.region_desc<device = "test1", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> -> memref<11xf32> {
+// CHECK: %[[R1:.*]] = numba_util.env_region #gpu_runtime.region_desc<device = "test1", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> -> memref<11xf32> {
+  %1 = numba_util.env_region #gpu_runtime.region_desc<device = "test1", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> -> memref<11xf32> {
 // CHECK: %[[A2:.*]] = gpu_runtime.alloc %[[S2]] () : memref<11xf32>
     %2 = gpu.alloc () : memref<11xf32>
 // CHECK: numba_util.env_region_yield %[[A2]] : memref<11xf32>
     numba_util.env_region_yield %2: memref<11xf32>
   }
-// CHECK: %[[R2:.*]] = numba_util.env_region #gpu_runtime.region_desc<device = "test2", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> -> memref<12xf32> {
-  %3 = numba_util.env_region #gpu_runtime.region_desc<device = "test2", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> -> memref<12xf32> {
+// CHECK: %[[R2:.*]] = numba_util.env_region #gpu_runtime.region_desc<device = "test2", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> -> memref<12xf32> {
+  %3 = numba_util.env_region #gpu_runtime.region_desc<device = "test2", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> -> memref<12xf32> {
 // CHECK: %[[A3:.*]] = gpu_runtime.alloc %[[S3]] () : memref<12xf32>
     %4 = gpu.alloc () : memref<12xf32>
 // CHECK: numba_util.env_region_yield %[[A3]] : memref<12xf32>

--- a/mlir/test/Transforms/gpux-sort-loops.mlir
+++ b/mlir/test/Transforms/gpux-sort-loops.mlir
@@ -10,7 +10,7 @@
 func.func @check(%arg0: memref<?x?xf64>, %arg1: memref<?x?xf64>, %arg2: index, %arg3: index) {
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
-  numba_util.env_region #gpu_runtime.region_desc<device = "test", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> {
+  numba_util.env_region #gpu_runtime.region_desc<device = "test", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> {
     scf.parallel (%arg4, %arg5) = (%c0, %c0) to (%arg2, %arg3) step (%c1, %c1) {
       %2 = memref.load %arg0[%arg4, %arg5] : memref<?x?xf64>
       memref.store %2, %arg1[%arg4, %arg5] : memref<?x?xf64>
@@ -34,7 +34,7 @@ func.func @check(%arg0: memref<?x?xf64>, %arg1: memref<?x?xf64>, %arg2: index, %
 func.func @check(%arg0: memref<?x?x?xf64>, %arg1: memref<?x?x?xf64>, %arg3: index, %arg4: index, %arg5: index) {
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
-  numba_util.env_region #gpu_runtime.region_desc<device = "test", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> {
+  numba_util.env_region #gpu_runtime.region_desc<device = "test", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> {
     scf.parallel (%arg6, %arg7, %arg8) = (%c0, %c0, %c0) to (%arg3, %arg4, %arg5) step (%c1, %c1, %c1) {
       %2 = memref.load %arg0[%arg6, %arg7, %arg8] : memref<?x?x?xf64>
       memref.store %2, %arg1[%arg6, %arg7, %arg8] : memref<?x?x?xf64>
@@ -58,7 +58,7 @@ func.func @check(%arg0: memref<?x?x?xf64>, %arg1: memref<?x?x?xf64>, %arg3: inde
 func.func @check(%arg0: memref<?x?x?xf64>, %arg1: memref<?x?x?xf64>, %arg3: index, %arg4: index, %arg5: index) {
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
-  numba_util.env_region #gpu_runtime.region_desc<device = "test", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> {
+  numba_util.env_region #gpu_runtime.region_desc<device = "test", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> {
     scf.parallel (%arg6, %arg7, %arg8) = (%c0, %c0, %c0) to (%arg3, %arg4, %arg5) step (%c1, %c1, %c1) {
       %2 = memref.load %arg0[%arg6, %arg8, %arg7] : memref<?x?x?xf64>
       memref.store %2, %arg1[%arg6, %arg8, %arg7] : memref<?x?x?xf64>

--- a/mlir/test/Transforms/gpux-tile-parallel.mlir
+++ b/mlir/test/Transforms/gpux-tile-parallel.mlir
@@ -5,7 +5,7 @@
 // CHECK: %[[C1:.*]] = arith.constant 1 : index
 // CHECK: %[[C0:.*]] = arith.constant 0 : index
 // CHECK: %[[DIM1:.*]] = memref.dim %[[MEM1]], %[[C0]] : memref<?xf64>
-// CHECK: numba_util.env_region #gpu_runtime.region_desc<device = "test", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false>
+// CHECK: numba_util.env_region #gpu_runtime.region_desc<device = "test", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false>
 // CHECK: %[[B:.*]]:3 = gpu_runtime.suggest_block_size, %[[DIM1]], %[[C1]], %[[C1]] -> index, index, index
 // CHECK: %[[G1:.*]] = arith.ceildivui %[[DIM1]], %[[B]]#0 : index
 // CHECK: scf.parallel
@@ -26,7 +26,7 @@ func.func @check1D(%arg0: memref<?xf64>, %arg1: memref<?xf64>) {
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
   %0 = memref.dim %arg0, %c0 : memref<?xf64>
-  numba_util.env_region #gpu_runtime.region_desc<device = "test", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> {
+  numba_util.env_region #gpu_runtime.region_desc<device = "test", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> {
     scf.parallel (%arg4) = (%c0) to (%0) step (%c1) {
       %2 = memref.load %arg0[%arg4] : memref<?xf64>
       memref.store %2, %arg1[%arg4] : memref<?xf64>
@@ -46,7 +46,7 @@ func.func @check1D(%arg0: memref<?xf64>, %arg1: memref<?xf64>) {
 // CHECK: %[[DIM1:.*]] = memref.dim %[[MEM1]], %[[C0]] : memref<?x?x?xf64>
 // CHECK: %[[DIM2:.*]] = memref.dim %[[MEM1]], %[[C1]] : memref<?x?x?xf64>
 // CHECK: %[[DIM3:.*]] = memref.dim %[[MEM1]], %[[C2]] : memref<?x?x?xf64>
-// CHECK: numba_util.env_region #gpu_runtime.region_desc<device = "test", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false>
+// CHECK: numba_util.env_region #gpu_runtime.region_desc<device = "test", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false>
 // CHECK: %[[B:.*]]:3 = gpu_runtime.suggest_block_size, %[[DIM1]], %[[DIM2]], %[[DIM3]] -> index, index, index
 // CHECK: %[[G1:.*]] = arith.ceildivui %[[DIM1]], %[[B]]#0 : index
 // CHECK: %[[G2:.*]] = arith.ceildivui %[[DIM2]], %[[B]]#1 : index
@@ -80,7 +80,7 @@ func.func @check3D(%arg0: memref<?x?x?xf64>, %arg1: memref<?x?x?xf64>) {
   %0 = memref.dim %arg0, %c0 : memref<?x?x?xf64>
   %1 = memref.dim %arg0, %c1 : memref<?x?x?xf64>
   %2 = memref.dim %arg0, %c2 : memref<?x?x?xf64>
-  numba_util.env_region #gpu_runtime.region_desc<device = "test", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> {
+  numba_util.env_region #gpu_runtime.region_desc<device = "test", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> {
     scf.parallel (%arg4, %arg5, %arg6) = (%c0, %c0, %c0) to (%0, %1, %2) step (%c1, %c1, %c1) {
       %3 = memref.load %arg0[%arg4, %arg5, %arg6] : memref<?x?x?xf64>
       memref.store %3, %arg1[%arg4, %arg5, %arg6] : memref<?x?x?xf64>
@@ -102,7 +102,7 @@ func.func @check3D(%arg0: memref<?x?x?xf64>, %arg1: memref<?x?x?xf64>) {
 // CHECK: %[[DIM2:.*]] = memref.dim %[[MEM1]], %[[C1]] : memref<?x?x?x?xf64>
 // CHECK: %[[DIM3:.*]] = memref.dim %[[MEM1]], %[[C2]] : memref<?x?x?x?xf64>
 // CHECK: %[[DIM4:.*]] = memref.dim %[[MEM1]], %[[C3]] : memref<?x?x?x?xf64>
-// CHECK: numba_util.env_region #gpu_runtime.region_desc<device = "test", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false>
+// CHECK: numba_util.env_region #gpu_runtime.region_desc<device = "test", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false>
 // CHECK: %[[B:.*]]:3 = gpu_runtime.suggest_block_size, %[[DIM1]], %[[DIM2]], %[[DIM3]] -> index, index, index
 // CHECK: %[[G1:.*]] = arith.ceildivui %[[DIM1]], %[[B]]#0 : index
 // CHECK: %[[G2:.*]] = arith.ceildivui %[[DIM2]], %[[B]]#1 : index
@@ -138,7 +138,7 @@ func.func @check4D(%arg0: memref<?x?x?x?xf64>, %arg1: memref<?x?x?x?xf64>) {
   %1 = memref.dim %arg0, %c1 : memref<?x?x?x?xf64>
   %2 = memref.dim %arg0, %c2 : memref<?x?x?x?xf64>
   %3 = memref.dim %arg0, %c3 : memref<?x?x?x?xf64>
-  numba_util.env_region #gpu_runtime.region_desc<device = "test", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> {
+  numba_util.env_region #gpu_runtime.region_desc<device = "test", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> {
     scf.parallel (%arg4, %arg5, %arg6, %arg7) = (%c0, %c0, %c0, %c0) to (%0, %1, %2, %3) step (%c1, %c1, %c1, %c1) {
       %4 = memref.load %arg0[%arg4, %arg5, %arg6, %arg7] : memref<?x?x?x?xf64>
       memref.store %4, %arg1[%arg4, %arg5, %arg6, %arg7] : memref<?x?x?x?xf64>
@@ -156,7 +156,7 @@ func.func @check4D(%arg0: memref<?x?x?x?xf64>, %arg1: memref<?x?x?x?xf64>) {
 // CHECK: %[[C1:.*]] = arith.constant 1 : index
 // CHECK: %[[C0:.*]] = arith.constant 0 : index
 // CHECK: %[[DIM1:.*]] = memref.dim %[[MEM1]], %[[C0]] : memref<?xf64>
-// CHECK: %[[RES1:.*]] = numba_util.env_region #gpu_runtime.region_desc<device = "test", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> -> f64
+// CHECK: %[[RES1:.*]] = numba_util.env_region #gpu_runtime.region_desc<device = "test", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> -> f64
 // CHECK: %[[B:.*]]:3 = gpu_runtime.suggest_block_size, %[[DIM1]], %[[C1]], %[[C1]] -> index, index, index
 // CHECK: %[[G1:.*]] = arith.ceildivui %[[DIM1]], %[[B]]#0 : index
 // CHECK: %[[RES2:.*]] = scf.parallel
@@ -187,7 +187,7 @@ func.func @check1DReduction(%arg0: memref<?xf64>, %arg1: memref<?xf64>, %arg2: f
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index
   %0 = memref.dim %arg0, %c0 : memref<?xf64>
-  %1 = numba_util.env_region #gpu_runtime.region_desc<device = "test", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> -> f64 {
+  %1 = numba_util.env_region #gpu_runtime.region_desc<device = "test", usm_type = "device", spirv_major_version = 1, spirv_minor_version = 1, has_fp16 = true, has_fp64 = false> -> f64 {
     %2 = scf.parallel (%arg4) = (%c0) to (%0) step (%c1) init(%arg2) -> f64 {
       %3 = memref.load %arg0[%arg4] : memref<?xf64>
       memref.store %3, %arg1[%arg4] : memref<?xf64>

--- a/mlir/test/Transforms/insert-global-reduce.mlir
+++ b/mlir/test/Transforms/insert-global-reduce.mlir
@@ -22,7 +22,7 @@ func.func @test(%lb: index, %ub: index, %s: index) {
 // CHECK-LABEL: @test
 //  CHECK-SAME: (%[[LB:.*]]: index, %[[UB:.*]]: index, %[[S:.*]]: index)
 //       CHECK: %[[INIT:.*]] = "test.init"() : () -> f32
-//       CHECK: %[[ARRAY:.*]] = memref.alloc() : memref<f32>
+//       CHECK: %[[ARRAY:.*]] = gpu.alloc host_shared () : memref<f32>
 //       CHECK: scf.parallel (%[[ARG1:.*]], %[[ARG2:.*]], %[[ARG3:.*]]) = (%[[LB]], %[[LB]], %[[LB]]) to (%[[UB]], %[[UB]], %[[UB]]) step (%[[S]], %[[S]], %[[S]]) {
 //       CHECK: %[[PROD:.*]] = "test.produce"() : () -> f32
 //       CHECK: gpu_runtime.global_reduce %[[PROD]], %[[ARRAY]] : memref<f32> {
@@ -33,7 +33,7 @@ func.func @test(%lb: index, %ub: index, %s: index) {
 //       CHECK: scf.yield
 //       CHECK: }
 //       CHECK: %[[RES1:.*]] = memref.load %[[ARRAY]][] : memref<f32>
-//       CHECK: memref.dealloc %[[ARRAY]] : memref<f32>
+//       CHECK: gpu.dealloc %[[ARRAY]] : memref<f32>
 //       CHECK: %[[RES2:.*]] = "test.transform"(%[[RES1]], %[[INIT]]) : (f32, f32) -> f32
 //       CHECK: "test.consume"(%[[RES2]]) : (f32) -> ()
 //       CHECK: return

--- a/numba_mlir/numba_mlir/mlir/dpctl_interop.py
+++ b/numba_mlir/numba_mlir/mlir/dpctl_interop.py
@@ -284,6 +284,7 @@ if _is_dpctl_available:
 
 else:  # _is_dpctl_available
     USMNdArrayType = None  # dummy
+    OtherUSMNdArray = None  # dummy
 
     def check_usm_ndarray_args(args):
         # dpctl is not loaded, nothing to do

--- a/numba_mlir/numba_mlir/mlir/dpctl_interop.py
+++ b/numba_mlir/numba_mlir/mlir/dpctl_interop.py
@@ -44,6 +44,27 @@ if _is_dpctl_available:
     from .target import typeof_impl
     from . import array_type
 
+    try:
+        from numba_dpex.core.types.usm_ndarray_type import USMNdArray as OtherUSMNdArray
+
+        # TODO: add to numba-dpex USMNdArray
+        def array_get_device_caps(obj):
+            if hasattr(obj, "_caps"):
+                return obj._caps
+
+            device = obj.device
+            if not device:
+                return None
+
+            caps = _get_device_caps(dpctl.SyclDevice(device))
+            setattr(obj, "_caps", caps)
+
+            return caps
+
+        setattr(OtherUSMNdArray, "get_device_caps", array_get_device_caps)
+    except ImportError:
+        OtherUSMNdArray = None
+
     def _get_device_caps(device):
         return DeviceCaps(
             filter_string=device.filter_string,

--- a/numba_mlir/numba_mlir/mlir/dpctl_interop.py
+++ b/numba_mlir/numba_mlir/mlir/dpctl_interop.py
@@ -201,6 +201,10 @@ if _is_dpctl_available:
                 device=self.device,
             )
 
+        @property
+        def key(self):
+            return super().key + (self.usm_type,)
+
     register_model(USMNdArrayType)(USMNdArrayModel)
 
     @typeof_impl.register(usm_ndarray)

--- a/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
@@ -1946,7 +1946,7 @@ def test_cfd_reduce2(py_func, shape, dtype, request):
     jit_func = njit(py_func)
     a = np.arange(1, count + 1, dtype=dtype).reshape(shape).copy()
 
-    da = _from_host(a, buffer="device")
+    da = _from_host(a, buffer="shared")
     assert_allclose(jit_func(da), py_func(a), rtol=1e-5)
 
 

--- a/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
@@ -28,6 +28,8 @@ _def_device = get_default_device().filter_string
 _has_fp64 = get_default_device().has_fp64
 _fp64_dtypes = {np.float64, np.complex128}
 
+require_f64 = pytest.mark.skipif(not _has_fp64, reason="Need f64 support")
+
 
 def skip_fp64_arg(arg):
     if _has_fp64:
@@ -340,6 +342,7 @@ def test_empty_kernel():
 
 
 @require_gpu
+@require_f64
 def test_f64_truncate():
     def func(a, b, c):
         i = get_global_id(0)

--- a/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
@@ -294,7 +294,9 @@ def test_scalar(val, dtype):
 
 @require_gpu
 @pytest.mark.parametrize("val", _test_values)
-@pytest.mark.parametrize("dtype", [np.int32, np.int64, np.float32, np.float64])
+@pytest.mark.parametrize(
+    "dtype", skip_fp64_args([np.int32, np.int64, np.float32, np.float64])
+)
 def test_scalar_cature(val, dtype):
     get_id = get_global_id
 
@@ -498,7 +500,7 @@ def _test_binary(func, dtype, ir_pass, ir_check):
 
 @require_gpu
 @pytest.mark.parametrize("op", ["sqrt", "log", "sin", "cos", "floor"])
-@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("dtype", skip_fp64_args([np.float32, np.float64]))
 def test_math_funcs_unary(op, dtype):
     f = eval(f"math.{op}")
 
@@ -511,7 +513,7 @@ def test_math_funcs_unary(op, dtype):
 
 @require_gpu
 @pytest.mark.parametrize("op", ["+", "-", "*", "/", "//", "%", "**"])
-@pytest.mark.parametrize("dtype", [np.int32, np.float32, np.float64])
+@pytest.mark.parametrize("dtype", skip_fp64_args([np.int32, np.float32, np.float64]))
 def test_gpu_ops_binary(op, dtype):
     f = eval(f"lambda a, b: a {op} b")
     inner = kernel_func(f)
@@ -764,7 +766,7 @@ def test_get_local_size(shape, lsize):
     assert_equal(gpu_res, sim_res)
 
 
-_atomic_dtypes = ["int32", "int64", "float32"]
+_atomic_dtypes = skip_fp64_args(["int32", "int64", "float32"])
 _atomic_funcs = [atomic.add, atomic.sub]
 
 

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -366,13 +366,14 @@ struct PlierLowerer final {
     mlir::Attribute env;
     if (!caps.is_none()) {
       auto device = caps.attr("filter_string").cast<std::string>();
+      auto usmType = "device";
       auto spirvMajor = caps.attr("spirv_major_version").cast<int16_t>();
       auto spirvMinor = caps.attr("spirv_minor_version").cast<int16_t>();
       auto hasFP16 = caps.attr("has_fp16").cast<bool>();
       auto hasFP64 = caps.attr("has_fp64").cast<bool>();
       env = gpu_runtime::GPURegionDescAttr::get(builder.getContext(), device,
-                                                spirvMajor, spirvMinor, hasFP16,
-                                                hasFP64);
+                                                usmType, spirvMajor, spirvMinor,
+                                                hasFP16, hasFP64);
     }
 
     builder.setInsertionPointToStart(block);

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/Lowering.cpp
@@ -428,35 +428,15 @@ struct PlierLowerer final {
       result = builder.create<numba::util::BuildTupleOp>(loc, resType, results);
     }
 
+    auto origFuncType = func.getFunctionType();
+    assert(origFuncType.getNumResults() == 1);
+    auto funcsResultType = origFuncType.getResults().front();
+    if (result.getType() != funcsResultType)
+      result = builder.create<plier::CastOp>(loc, funcsResultType, result);
+
     builder.create<mlir::func::ReturnOp>(loc, result);
 
     fixupPhis();
-
-    if (env) {
-      builder.setInsertionPointToStart(block);
-
-      llvm::SmallVector<mlir::Type> newArgsTypes;
-      for (auto arg : block->getArguments()) {
-        auto argType = arg.getType();
-        newArgsTypes.emplace_back(argType);
-        auto origType = argType.dyn_cast<numba::ntensor::NTensorType>();
-        if (!origType || origType.getEnvironment())
-          continue;
-
-        auto newType = numba::ntensor::NTensorType::get(
-            builder.getContext(), origType.getShape(),
-            origType.getElementType(), env, origType.getLayout());
-        arg.setType(newType);
-        auto cast = builder.create<numba::ntensor::CastOp>(getCurrentLoc(),
-                                                           origType, arg);
-        arg.replaceAllUsesExcept(cast.getResult(), cast);
-        newArgsTypes.back() = newType;
-      }
-      auto origFuncType = func.getFunctionType();
-      auto newFuncType =
-          origFuncType.clone(newArgsTypes, origFuncType.getResults());
-      func.setFunctionType(newFuncType);
-    }
     return newFunc;
   }
 

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -2220,7 +2220,7 @@ static void populateLowerToGPUPipelineRegion(mlir::OpPassManager &pm) {
 }
 
 static void populateLowerToGPUPipelineHigh(mlir::OpPassManager &pm) {
-  pm.addNestedPass<mlir::func::FuncOp>(std::make_unique<MarkGpuArraysInputs>());
+  //  pm.addNestedPass<mlir::func::FuncOp>(std::make_unique<MarkGpuArraysInputs>());
   pm.addPass(std::make_unique<LowerGpuBuiltinsPass>());
   commonOptPasses(pm);
   pm.addPass(mlir::createSymbolDCEPass());
@@ -2241,7 +2241,8 @@ static void populateLowerToGPUPipelineMed(mlir::OpPassManager &pm) {
   funcPM.addPass(mlir::createCanonicalizerPass());
   funcPM.addPass(gpu_runtime::createLowerGPUGlobalReducePass());
   commonOptPasses(funcPM);
-  funcPM.addPass(gpu_runtime::createInsertGPUAllocsPass());
+  //  funcPM.addPass(gpu_runtime::createInsertGPUAllocsPass());
+  funcPM.addPass(gpu_runtime::createCreateGPUAllocPass());
   funcPM.addPass(mlir::createCanonicalizerPass());
   funcPM.addPass(std::make_unique<LowerGpuBuiltins2Pass>());
   funcPM.addPass(gpu_runtime::createGpuDecomposeMemrefsPass());

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpu.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpu.cpp
@@ -997,21 +997,10 @@ getDeviceDescFromArgs(mlir::MLIRContext *context, mlir::TypeRange argTypes) {
 static mlir::FailureOr<mlir::Attribute>
 getDeviceDescFromFunc(mlir::MLIRContext *context, mlir::TypeRange argTypes) {
   auto res = getDeviceDescFromArgs(context, argTypes);
-  if (mlir::failed(res))
+  if (mlir::failed(res) || !*res)
     return mlir::failure();
 
-  // TODO: remove default device.
-  if (*res)
-    return res;
-
-  if (auto dev = numba::getDefaultDevice()) {
-    auto &&[device, caps] = *dev;
-    return gpu_runtime::GPURegionDescAttr::get(
-        context, device, caps.spirvMajorVersion, caps.spirvMinorVersion,
-        caps.hasFP16, caps.hasFP64);
-  } else {
-    return mlir::failure();
-  }
+  return *res;
 }
 
 static bool isGpuArray(mlir::Type type) {

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpuTypeConversion.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToGpuTypeConversion.cpp
@@ -53,13 +53,15 @@ struct Conversion {
     if (caps.is_none())
       return std::nullopt;
 
+    auto usmType = obj.attr("usm_type").cast<std::string>();
+
     auto device = caps.attr("filter_string").cast<std::string>();
     auto spirvMajor = caps.attr("spirv_major_version").cast<int16_t>();
     auto spirvMinor = caps.attr("spirv_minor_version").cast<int16_t>();
     auto hasFP16 = caps.attr("has_fp16").cast<bool>();
     auto hasFP64 = caps.attr("has_fp64").cast<bool>();
     auto env = gpu_runtime::GPURegionDescAttr::get(
-        &context, device, spirvMajor, spirvMinor, hasFP16, hasFP64);
+        &context, device, usmType, spirvMajor, spirvMinor, hasFP16, hasFP64);
 
     return numba::ntensor::NTensorType::get(shape, elemType, env,
                                             llvm::StringRef(layout));

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -2366,10 +2366,14 @@ struct WrapParforRegionsPass
 
         if (!env) {
           env = *opEnv;
-        } else if (*env != *opEnv) {
+          return mlir::WalkResult::advance();
+        }
+        auto res = numba::util::mergeEnvAttrs(*env, *opEnv);
+        if (!res) {
           forOp->emitError("Incompatible envs: ") << *env << " and " << *opEnv;
           return mlir::WalkResult::interrupt();
         }
+        env = *res;
         return mlir::WalkResult::advance();
       };
       if (forOp->walk(innerVisitor).wasInterrupted())

--- a/numba_mlir_gpu_common/GpuCommon.hpp
+++ b/numba_mlir_gpu_common/GpuCommon.hpp
@@ -27,7 +27,7 @@ public:
   virtual sycl::queue *getQueue() = 0;
 };
 
-enum class GpuAllocType { Device = 0, Shared = 1, Local = 2 };
+enum class GpuAllocType { Device = 0, Shared = 1, Local = 2, Host = 3 };
 
 enum class GpuParamType : int32_t {
   null = 0,

--- a/numba_mlir_gpu_runtime_sycl/lib/GpuRuntime.cpp
+++ b/numba_mlir_gpu_runtime_sycl/lib/GpuRuntime.cpp
@@ -211,6 +211,9 @@ public:
       } else if (type == numba::GpuAllocType::Local) {
         // Local allocs are handled specially, do not allocate any pointer on
         // host side.
+      } else if (type == numba::GpuAllocType::Host) {
+        ret = CHECK_ALLOC(sycl::aligned_alloc_host(alignment, size, queue),
+                          shared);
       } else {
         throw std::runtime_error("Invalid allocation type");
       }


### PR DESCRIPTION
* Previously allocation type was selected based on access patterns of specific memrefs, now, select it based on actual `usm_type` which came as part of input type.
* Using numpy arrays inside kernels are no longer supported as we are not going to insert automatic data transfer between host and device.
* Support `host` SYCL allocations
* Add `DialectEnvInterface` to allow dialects override how region envs are merged. Needed to handle mixing different `usm_type`s inside same gpu region.
* Update GPU tests to always use `dpctl` instead of numpy arrays.