### PR TITLE
Set higher benefit to `ConvertYieldOpTypes` so it's always run before upstream patterns.

### DIFF
--- a/mlir/lib/Transforms/TypeConversion.cpp
+++ b/mlir/lib/Transforms/TypeConversion.cpp
@@ -399,7 +399,10 @@ public:
 
 class ConvertYieldOpTypes : public OpConversionPattern<scf::YieldOp> {
 public:
-  using OpConversionPattern::OpConversionPattern;
+  ConvertYieldOpTypes(TypeConverter &typeConverter, MLIRContext *context)
+      : OpConversionPattern<scf::YieldOp>(typeConverter, context,
+                                          /*benefit*/ 10) {}
+
   LogicalResult
   matchAndRewrite(scf::YieldOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {


### PR DESCRIPTION
* Should fix dbscan WL
