### PR TITLE
Ntensor reshape refactoring

### DIFF
--- a/mlir/include/numba/Dialect/numba_util/NumbaUtilOps.td
+++ b/mlir/include/numba/Dialect/numba_util/NumbaUtilOps.td
@@ -399,20 +399,37 @@ def GetAllocTokenOp : NumbaUtil_Op<"get_alloc_token", [
 def ReshapeOp : NumbaUtil_Op<"reshape", [
     Pure, ViewLikeOpInterface]> {
 
+  let summary = "Shaped type reshape operation";
+  let description = [{
+    Reshapes source into provided shape.
+
+    Total elements count in source array must match destination shape.
+
+    Reshape may be lowered either into copy or memory view, depending on
+    lowering strategy, arg types and inferred layout.
+  }];
+
   let arguments = (ins
     AnyShaped:$source,
     Variadic<Index>:$shape
   );
+
   let results = (outs AnyShaped:$result);
 
   let extraClassDeclaration = [{
       ::mlir::Value getViewSource() { return getSource(); }
   }];
 
-
   let assemblyFormat = [{
     $source `(` $shape `)` attr-dict `:` functional-type(operands, results)
   }];
+
+  let builders = [
+    OpBuilder<(ins
+      "::mlir::Value":$source,
+      "::mlir::ValueRange":$shape
+    )>
+  ];
 }
 
 

--- a/mlir/lib/Dialect/numba_util/Dialect.cpp
+++ b/mlir/lib/Dialect/numba_util/Dialect.cpp
@@ -2571,6 +2571,14 @@ void GetAllocTokenOp::getCanonicalizationPatterns(
   results.insert<PropagateAllocTokenCasts>(context);
 }
 
+void ReshapeOp::build(mlir::OpBuilder &b, mlir::OperationState &result,
+                      mlir::Value source, mlir::ValueRange shape) {
+  auto shaped = mlir::cast<mlir::ShapedType>(source.getType());
+  llvm::SmallVector<int64_t> resShape(shape.size(), mlir::ShapedType::kDynamic);
+  auto resType = shaped.clone(resShape);
+  build(b, result, resType, source, shape);
+}
+
 std::optional<mlir::Attribute> mergeEnvAttrs(mlir::Attribute env1,
                                              mlir::Attribute env2) {
   if (env1 == env2)


### PR DESCRIPTION
* Emit `util.reshape` op in PyLinalgResolver instead of emitting linalg ops directly
* Add corresponding lowering paths ntensor->linalg and ntensor->memref to handle reshape on ntensor type
* Update `PromoteBoolMemrefsPass`