### PR TITLE
Copy removal pass fixes

### DIFF
--- a/mlir/include/numba/Transforms/CopyRemoval.hpp
+++ b/mlir/include/numba/Transforms/CopyRemoval.hpp
@@ -4,16 +4,11 @@
 
 #pragma once
 
-#include "numba/Analysis/AliasAnalysis.hpp"
+#include <memory>
 
-#include <mlir/IR/Dominance.h>
-#include <mlir/Interfaces/FunctionInterfaces.h>
-#include <mlir/Interfaces/SideEffectInterfaces.h>
-#include <mlir/Pass/Pass.h>
-
-#include "numba/Dialect/ntensor/IR/NTensorOps.hpp"
-
-#include <functional>
+namespace mlir {
+class Pass;
+}
 
 namespace numba {
 std::unique_ptr<mlir::Pass> createCopyRemovalPass();

--- a/mlir/lib/Transforms/CopyRemoval.cpp
+++ b/mlir/lib/Transforms/CopyRemoval.cpp
@@ -2,13 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "numba/Transforms/CopyRemoval.hpp"
+
 #include "numba/Analysis/AliasAnalysis.hpp"
 
-#include <mlir/Interfaces/LoopLikeInterface.h>
 #include <mlir/Dialect/Linalg/IR/Linalg.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/IR/Dominance.h>
 #include <mlir/Interfaces/FunctionInterfaces.h>
+#include <mlir/Interfaces/LoopLikeInterface.h>
 #include <mlir/Interfaces/SideEffectInterfaces.h>
 #include <mlir/Pass/Pass.h>
 
@@ -72,7 +74,7 @@ static bool isLocallyAllocated(mlir::Value value) {
       value.getDefiningOp());
 }
 
-static mlir::Value CastTensor(mlir::OpBuilder &builder, mlir::Location &loc,
+static mlir::Value castTensor(mlir::OpBuilder &builder, mlir::Location &loc,
                               mlir::Value src, mlir::Value dst) {
   if (mlir::isa_and_nonnull<numba::ntensor::NTensorType>(src.getType()))
     return builder.create<numba::ntensor::CastOp>(loc, dst.getType(), src);
@@ -106,7 +108,7 @@ static mlir::Value getCopyOpTarget(mlir::Operation &op) {
   llvm_unreachable("Unknown tensor type");
 }
 
-namespace numba {
+namespace {
 struct CopyRemovalPass
     : public mlir::PassWrapper<CopyRemovalPass,
                                mlir::InterfacePass<mlir::FunctionOpInterface>> {
@@ -148,15 +150,15 @@ struct CopyRemovalPass
     });
 
     if (copies.empty())
-      return this->markAllAnalysesPreserved();
+      return markAllAnalysesPreserved();
 
-    auto &dom = this->template getAnalysis<mlir::DominanceInfo>();
-    auto &postDom = this->template getAnalysis<mlir::PostDominanceInfo>();
-    auto &aa = this->template getAnalysis<numba::LocalAliasAnalysis>();
+    auto &dom = getAnalysis<mlir::DominanceInfo>();
+    auto &postDom = getAnalysis<mlir::PostDominanceInfo>();
+    auto &aa = getAnalysis<numba::LocalAliasAnalysis>();
 
     auto inBetween = [&](mlir::Operation *op, mlir::Operation *begin,
                          mlir::Operation *end) -> bool {
-      mlir::Operation* loop = end;
+      mlir::Operation *loop = end;
       while ((loop = loop->getParentOfType<mlir::LoopLikeOpInterface>())) {
         if (!loop->isProperAncestor(begin) && loop->isProperAncestor(op))
           return true;
@@ -188,7 +190,7 @@ struct CopyRemovalPass
       return false;
     };
 
-    mlir::OpBuilder builder(&this->getContext());
+    mlir::OpBuilder builder(&getContext());
 
     // Propagate copy src.
     for (auto copy : copies) {
@@ -214,7 +216,7 @@ struct CopyRemovalPass
         if (src.getType() != dst.getType()) {
           auto loc = owner->getLoc();
           builder.setInsertionPoint(owner);
-          newArg = CastTensor(builder, loc, newArg, dst);
+          newArg = castTensor(builder, loc, newArg, dst);
         }
 
         use.set(newArg);
@@ -286,8 +288,8 @@ struct CopyRemovalPass
       op->erase();
   }
 };
+} // namespace
 
-std::unique_ptr<mlir::Pass> createCopyRemovalPass() {
-  return std::unique_ptr<mlir::Pass>(new CopyRemovalPass());
+std::unique_ptr<mlir::Pass> numba::createCopyRemovalPass() {
+  return std::make_unique<CopyRemovalPass>();
 }
-} // namespace numba

--- a/mlir/test/Transforms/copy-removal.mlir
+++ b/mlir/test/Transforms/copy-removal.mlir
@@ -149,4 +149,3 @@ func.func @test(%arg1: memref<?xf32>, %arg2: memref<?xf32>) {
   }
   return
 }
-


### PR DESCRIPTION
* Simple dominance checks are not enough when dealing with loops, as writes/reads from prev iterations can affect ops even if they are not directly dominate.
* For now, hacked with `LoopLikeOpInterface`, but we really need dataflow analysis for this.
* Some style fixes