### PR TITLE
Tensor lowering refac

### DIFF
--- a/mlir/include/numba/Conversion/NtensorToLinalg.hpp
+++ b/mlir/include/numba/Conversion/NtensorToLinalg.hpp
@@ -20,4 +20,6 @@ std::unique_ptr<mlir::Pass> createNtensorAliasAnalysisPass();
 
 /// Creates a pass to convert ntensor array ops to linalg.
 std::unique_ptr<mlir::Pass> createNtensorToLinalgPass();
+
+std::unique_ptr<mlir::Pass> createNtensorLowerToTensorCopyPass();
 } // namespace numba

--- a/mlir/include/numba/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/numba/Dialect/ntensor/IR/NTensorOps.td
@@ -687,6 +687,20 @@ def ToTensorOp : NTensor_OpBase<"to_tensor",
   }];
 }
 
+def ToTensorCopyOp : NTensor_OpBase<"to_tensor_copy",
+    [SameOperandsShape, SameOperandsElementType]> {
+  let summary = "converts ntensor array to tensor.";
+  let description = [{
+    Copy array into newly allocated tensor. Shape and element type must match.
+  }];
+
+  let arguments = (ins Arg<NTensor_Tensor,
+                       "the reference to load from", [MemRead]>:$array);
+  let results = (outs Res<Variadic<AnyRankedTensor>, "", [MemAlloc<DefaultResource>]>:$result);
+
+  let assemblyFormat = "$array attr-dict `:` qualified(type($array)) `to` type($result)";
+}
+
 def FromMemrefOp : NTensor_OpBase<"from_memref",
     [Pure, SameOperandsShape, SameOperandsElementType, ViewLikeOpInterface]> {
   let summary = "converts memref to ntensor array.";

--- a/mlir/include/numba/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/numba/Dialect/ntensor/IR/NTensorOps.td
@@ -696,7 +696,7 @@ def ToTensorCopyOp : NTensor_OpBase<"to_tensor_copy",
 
   let arguments = (ins Arg<NTensor_Tensor,
                        "the reference to load from", [MemRead]>:$array);
-  let results = (outs Res<Variadic<AnyRankedTensor>, "", [MemAlloc<DefaultResource>]>:$result);
+  let results = (outs Res<AnyRankedTensor, "", [MemAlloc<DefaultResource>]>:$result);
 
   let assemblyFormat = "$array attr-dict `:` qualified(type($array)) `to` type($result)";
 }

--- a/mlir/include/numba/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/numba/Dialect/ntensor/IR/NTensorOps.td
@@ -699,6 +699,8 @@ def ToTensorCopyOp : NTensor_OpBase<"to_tensor_copy",
   let results = (outs Res<AnyRankedTensor, "", [MemAlloc<DefaultResource>]>:$result);
 
   let assemblyFormat = "$array attr-dict `:` qualified(type($array)) `to` type($result)";
+
+  let hasFolder = 1;
 }
 
 def FromMemrefOp : NTensor_OpBase<"from_memref",

--- a/mlir/include/numba/Dialect/ntensor/IR/NTensorOps.td
+++ b/mlir/include/numba/Dialect/ntensor/IR/NTensorOps.td
@@ -655,7 +655,7 @@ def FromTensorOp : NTensor_OpBase<"from_tensor",
   }];
 
   let arguments = (ins AnyRankedTensor:$tensor);
-  let results = (outs Res<NTensor_Tensor, "", [MemAlloc<DefaultResource>]>:$result);
+  let results = (outs NTensor_Tensor:$result);
 
   let assemblyFormat = "$tensor attr-dict `:` type($tensor) `to` qualified(type($result))";
 
@@ -668,14 +668,13 @@ def FromTensorOp : NTensor_OpBase<"from_tensor",
 }
 
 def ToTensorOp : NTensor_OpBase<"to_tensor",
-    [SameOperandsShape, SameOperandsElementType, ViewLikeOpInterface]> {
+    [Pure, SameOperandsShape, SameOperandsElementType, ViewLikeOpInterface]> {
   let summary = "converts ntensor array to tensor.";
   let description = [{
     Converts from ntensor array to tensor. Shape and element type must match.
   }];
 
-  let arguments = (ins Arg<NTensor_Tensor,
-                       "the reference to load from", [MemRead]>:$array);
+  let arguments = (ins NTensor_Tensor:$array);
   let results = (outs AnyRankedTensor:$result);
 
   let assemblyFormat = "$array attr-dict `:` qualified(type($array)) `to` type($result)";
@@ -696,7 +695,7 @@ def ToTensorCopyOp : NTensor_OpBase<"to_tensor_copy",
 
   let arguments = (ins Arg<NTensor_Tensor,
                        "the reference to load from", [MemRead]>:$array);
-  let results = (outs Res<AnyRankedTensor, "", [MemAlloc<DefaultResource>]>:$result);
+  let results = (outs AnyRankedTensor:$result);
 
   let assemblyFormat = "$array attr-dict `:` qualified(type($array)) `to` type($result)";
 

--- a/mlir/lib/Analysis/AliasAnalysis.cpp
+++ b/mlir/lib/Analysis/AliasAnalysis.cpp
@@ -41,7 +41,8 @@ static bool isReferenceType(mlir::Value val) {
 
 static std::optional<mlir::AliasResult> checkLinalgImpl(mlir::Value val) {
   auto op = val.getDefiningOp();
-  if (mlir::isa_and_nonnull<mlir::linalg::GenericOp, mlir::tensor::EmptyOp>(op))
+  if (op && mlir::isa<mlir::linalg::LinalgDialect, mlir::tensor::TensorDialect>(
+                op->getDialect()))
     return mlir::AliasResult::NoAlias;
 
   return std::nullopt;

--- a/mlir/lib/Conversion/NtensorToLinalg.cpp
+++ b/mlir/lib/Conversion/NtensorToLinalg.cpp
@@ -98,8 +98,9 @@ struct ConvertCopyOp : public mlir::OpRewritePattern<numba::ntensor::CopyOp> {
           auto rank = static_cast<unsigned>(srcType.getRank());
 
           auto srcTensorType = toTensorType(srcType);
-          mlir::Value srcTensor = builder.create<numba::ntensor::ToTensorOp>(
-              loc, srcTensorType, src);
+          mlir::Value srcTensor =
+              builder.create<numba::ntensor::ToTensorCopyOp>(loc, srcTensorType,
+                                                             src);
 
           auto dstMemrefType = mlir::MemRefType::get(dstType.getShape(),
                                                      dstType.getElementType());
@@ -172,7 +173,7 @@ struct ConvertElementwiseOp
           for (auto &&[i, arg] : llvm::enumerate(src)) {
             auto srcTensorType =
                 toTensorType(arg.getType().cast<numba::ntensor::NTensorType>());
-            inputs[i] = builder.create<numba::ntensor::ToTensorOp>(
+            inputs[i] = builder.create<numba::ntensor::ToTensorCopyOp>(
                 loc, srcTensorType, arg);
           }
 
@@ -267,7 +268,7 @@ struct ConvertCastOp : public mlir::OpRewritePattern<numba::ntensor::CastOp> {
     auto results = numba::util::wrapEnvRegion(
         rewriter, op->getLoc(), dstType.getEnvironment(), dstType,
         [&](mlir::PatternRewriter &builder, mlir::Location loc) {
-          auto srcTensor = builder.create<numba::ntensor::ToTensorOp>(
+          auto srcTensor = builder.create<numba::ntensor::ToTensorCopyOp>(
               loc, srcTensorType, src);
           auto cast = builder.create<mlir::tensor::CastOp>(loc, dstTensorType,
                                                            srcTensor);
@@ -421,8 +422,9 @@ struct ConvertLoadOp : public mlir::OpRewritePattern<numba::ntensor::LoadOp> {
         srcType.getElementType(),
         [&](mlir::PatternRewriter &builder, mlir::Location loc) {
           auto srcTensorType = toTensorType(srcType);
-          mlir::Value srcTensor = builder.create<numba::ntensor::ToTensorOp>(
-              loc, srcTensorType, src);
+          mlir::Value srcTensor =
+              builder.create<numba::ntensor::ToTensorCopyOp>(loc, srcTensorType,
+                                                             src);
 
           mlir::Value result = builder.create<mlir::tensor::ExtractOp>(
               loc, srcTensor, op.getIndices());
@@ -609,7 +611,7 @@ struct ConvertBroadcastOp
           for (auto &&[i, input] : llvm::enumerate(inputs)) {
             auto tensorType = toTensorType(
                 input.getType().cast<numba::ntensor::NTensorType>());
-            tensorInputs[i] = rewriter.create<numba::ntensor::ToTensorOp>(
+            tensorInputs[i] = rewriter.create<numba::ntensor::ToTensorCopyOp>(
                 loc, tensorType, input);
           }
 

--- a/mlir/lib/Conversion/NtensorToLinalg.cpp
+++ b/mlir/lib/Conversion/NtensorToLinalg.cpp
@@ -868,7 +868,7 @@ struct NtensorLowerToTensorCopyPass
         auto dstShape = resType.getShape();
         tmp.clear();
         for (auto &&[i, s] : llvm::enumerate(dstShape)) {
-          if (!mlir::ShapedType::isDynamic(s))
+          if (mlir::ShapedType::isDynamic(s))
             tmp.emplace_back(
                 builder.create<numba::ntensor::DimOp>(loc, src, i));
         }

--- a/mlir/lib/Conversion/NtensorToLinalg.cpp
+++ b/mlir/lib/Conversion/NtensorToLinalg.cpp
@@ -409,9 +409,6 @@ struct ConvertLoadOp : public mlir::OpRewritePattern<numba::ntensor::LoadOp> {
   mlir::LogicalResult
   matchAndRewrite(numba::ntensor::LoadOp op,
                   mlir::PatternRewriter &rewriter) const override {
-    if (!op->hasAttr(kReadonly))
-      return mlir::failure();
-
     auto src = op.getArray();
     auto srcType = getNTensorType(src);
     if (!srcType || op.getType() != srcType.getElementType())
@@ -763,9 +760,6 @@ struct NtensorAliasAnalysisPass
 
       if (auto cast = mlir::dyn_cast<numba::ntensor::CastOp>(op))
         return cast.getDest();
-
-      if (auto load = mlir::dyn_cast<numba::ntensor::LoadOp>(op))
-        return load.getArray();
 
       if (auto reshape = mlir::dyn_cast<numba::util::ReshapeOp>(op))
         return reshape.getSource();

--- a/mlir/lib/Dialect/ntensor/IR/NTensorOps.cpp
+++ b/mlir/lib/Dialect/ntensor/IR/NTensorOps.cpp
@@ -411,6 +411,23 @@ struct ToTensorDimPropagate
   }
 };
 
+struct ToTensorCopyDimPropagate
+    : public mlir::OpRewritePattern<mlir::tensor::DimOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::tensor::DimOp op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto src = op.getSource().getDefiningOp<numba::ntensor::ToTensorCopyOp>();
+    if (!src)
+      return mlir::failure();
+
+    rewriter.replaceOpWithNewOp<numba::ntensor::DimOp>(op, src.getArray(),
+                                                       op.getIndex());
+    return mlir::success();
+  }
+};
+
 // TODO: upstream
 struct LinalgGenericDimPropagate
     : public mlir::OpRewritePattern<mlir::tensor::DimOp> {
@@ -481,7 +498,8 @@ struct ExtractSliceDimPropagate
 void numba::ntensor::DimOp::getCanonicalizationPatterns(
     ::mlir::RewritePatternSet &results, ::mlir::MLIRContext *context) {
   results.insert<FromTensorDimPropagate, ToTensorDimPropagate,
-                 LinalgGenericDimPropagate, ExtractSliceDimPropagate>(context);
+                 ToTensorCopyDimPropagate, LinalgGenericDimPropagate,
+                 ExtractSliceDimPropagate>(context);
 }
 
 mlir::OpFoldResult numba::ntensor::DimOp::fold(FoldAdaptor) {

--- a/mlir/lib/Dialect/ntensor/IR/NTensorOps.cpp
+++ b/mlir/lib/Dialect/ntensor/IR/NTensorOps.cpp
@@ -923,6 +923,19 @@ mlir::OpFoldResult numba::ntensor::ToTensorOp::fold(FoldAdaptor) {
   return nullptr;
 }
 
+mlir::OpFoldResult numba::ntensor::ToTensorCopyOp::fold(FoldAdaptor) {
+  auto arr = getArray();
+  if (auto from = arr.getDefiningOp<numba::ntensor::FromTensorOp>()) {
+    if (!arr.hasOneUse())
+      return nullptr;
+
+    auto val = from.getTensor();
+    if (getType() == val.getType())
+      return val;
+  }
+  return nullptr;
+}
+
 mlir::OpFoldResult numba::ntensor::FromMemrefOp::fold(FoldAdaptor) {
   if (auto to = getMemref().getDefiningOp<numba::ntensor::ToMemrefOp>()) {
     auto array = to.getArray();

--- a/mlir/lib/Dialect/ntensor/IR/NTensorOps.cpp
+++ b/mlir/lib/Dialect/ntensor/IR/NTensorOps.cpp
@@ -899,26 +899,7 @@ mlir::OpFoldResult numba::ntensor::ToTensorOp::fold(FoldAdaptor) {
   }
   if (auto from = arr.getDefiningOp<numba::ntensor::FromTensorOp>()) {
     auto val = from.getTensor();
-    auto haveOnlySafeUses = [](mlir::Operation *op) -> bool {
-      // Fold if we are the only user.
-      if (op->hasOneUse())
-        return true;
-
-      for (auto user : op->getUsers()) {
-        if (!mlir::isa<ToTensorOp>(user))
-          return false;
-
-        // Fold only other ops cannot create aliases.
-        for (auto tensorUser : user->getUsers())
-          if (!mlir::isa<mlir::tensor::DimOp, mlir::tensor::ExtractOp,
-                         mlir::linalg::GenericOp>(tensorUser))
-            return false;
-      }
-
-      return true;
-    };
-
-    if (getType() == val.getType() && haveOnlySafeUses(from))
+    if (getType() == val.getType())
       return val;
   }
   return nullptr;

--- a/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
+++ b/mlir/lib/Transforms/ShapeIntegerRangePropagation.cpp
@@ -143,7 +143,8 @@ struct ShapeValueLattice : public mlir::dataflow::Lattice<ShapeValue> {
 
 static bool isShapedCast(mlir::Operation *op) {
   if (mlir::isa<numba::ntensor::FromTensorOp, numba::ntensor::ToTensorOp,
-                numba::ntensor::FromMemrefOp, numba::ntensor::ToMemrefOp>(op))
+                numba::ntensor::ToTensorCopyOp, numba::ntensor::FromMemrefOp,
+                numba::ntensor::ToMemrefOp>(op))
     return true;
 
   return mlir::isa<mlir::CastOpInterface>(op) && op->getNumOperands() == 1 &&

--- a/mlir/test/Dialect/ntensor/canonicalize.mlir
+++ b/mlir/test/Dialect/ntensor/canonicalize.mlir
@@ -108,21 +108,6 @@ func.func @test(%arg1: tensor<?xf32>) -> tensor<?xf32> {
 
 // -----
 
-func.func @test(%arg1: tensor<?xf32>) -> tensor<?xf32> {
-  %0 = ntensor.from_tensor %arg1 : tensor<?xf32> to !ntensor.ntensor<?xf32>
-  "test.test5"(%0) : (!ntensor.ntensor<?xf32>) -> ()
-  %1 = ntensor.to_tensor %0 : !ntensor.ntensor<?xf32> to tensor<?xf32>
-  return %1 : tensor<?xf32>
-}
-// CHECK-LABEL: func @test
-//  CHECK-SAME:   (%[[ARG:.*]]: tensor<?xf32>)
-//  CHECK-NEXT:   %[[TMP:.*]] = ntensor.from_tensor %[[ARG]] : tensor<?xf32> to !ntensor.ntensor<?xf32>
-//  CHECK-NEXT:   "test.test5"(%[[TMP]]) : (!ntensor.ntensor<?xf32>) -> ()
-//  CHECK-NEXT:   %[[RES:.*]] = ntensor.to_tensor %[[TMP]] : !ntensor.ntensor<?xf32> to tensor<?xf32>
-//  CHECK-NEXT:   return %[[RES]] : tensor<?xf32>
-
-// -----
-
 func.func @test(%arg1: !ntensor.ntensor<?xf32>) -> !ntensor.ntensor<?xf32> {
   %0 = ntensor.to_tensor %arg1 : !ntensor.ntensor<?xf32> to tensor<?xf32>
   %1 = ntensor.from_tensor %0 : tensor<?xf32> to !ntensor.ntensor<?xf32>

--- a/mlir/test/Dialect/ntensor/ntensor-to-linalg.mlir
+++ b/mlir/test/Dialect/ntensor/ntensor-to-linalg.mlir
@@ -78,7 +78,7 @@ func.func @test(%arg1: !ntensor.ntensor<?xf32>, %arg2: !ntensor.ntensor<?xf32>) 
 }
 // CHECK-LABEL: func @test
 //  CHECK-SAME:   (%[[ARG1:.*]]: !ntensor.ntensor<?xf32>, %[[ARG2:.*]]: !ntensor.ntensor<?xf32>)
-//  CHECK-NEXT:   %[[SRC:.*]] = ntensor.to_tensor %[[ARG1]] : !ntensor.ntensor<?xf32> to tensor<?xf32>
+//  CHECK-NEXT:   %[[SRC:.*]] = ntensor.to_tensor_copy %[[ARG1]] : !ntensor.ntensor<?xf32> to tensor<?xf32>
 //  CHECK-NEXT:   %[[DST:.*]] = ntensor.to_memref %[[ARG2]] : !ntensor.ntensor<?xf32> to memref<?xf32>
 //  CHECK-NEXT:   linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%[[SRC]] : tensor<?xf32>) outs(%[[DST]] : memref<?xf32>) {
 //  CHECK-NEXT:   ^bb0(%[[BARG1:.*]]: f32, %[[ARG2:.*]]: f32):
@@ -95,7 +95,7 @@ func.func @test(%arg1: !ntensor.ntensor<?xf32, "test">, %arg2: !ntensor.ntensor<
 // CHECK-LABEL: func @test
 //  CHECK-SAME:   (%[[ARG1:.*]]: !ntensor.ntensor<?xf32, "test">, %[[ARG2:.*]]: !ntensor.ntensor<?xf32, "test">)
 //  CHECK-NEXT:   numba_util.env_region "test" {
-//  CHECK-NEXT:   %[[SRC:.*]] = ntensor.to_tensor %[[ARG1]] : !ntensor.ntensor<?xf32, "test"> to tensor<?xf32>
+//  CHECK-NEXT:   %[[SRC:.*]] = ntensor.to_tensor_copy %[[ARG1]] : !ntensor.ntensor<?xf32, "test"> to tensor<?xf32>
 //  CHECK-NEXT:   %[[DST:.*]] = ntensor.to_memref %[[ARG2]] : !ntensor.ntensor<?xf32, "test"> to memref<?xf32>
 //  CHECK-NEXT:   linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%[[SRC]] : tensor<?xf32>) outs(%[[DST]] : memref<?xf32>) {
 //  CHECK-NEXT:   ^bb0(%[[BARG1:.*]]: f32, %[[ARG2:.*]]: f32):
@@ -117,7 +117,7 @@ func.func @test(%arg1: !ntensor.ntensor<?x5xf32>) -> !ntensor.ntensor<?x5xf32> {
 // CHECK-LABEL: func @test
 //  CHECK-SAME:   (%[[ARG:.*]]: !ntensor.ntensor<?x5xf32>)
 //  CHECK-NEXT:   %[[C0:.*]] = arith.constant 0 : index
-//  CHECK-NEXT:   %[[T1:.*]] = ntensor.to_tensor %[[ARG]] : !ntensor.ntensor<?x5xf32> to tensor<?x5xf32>
+//  CHECK-NEXT:   %[[T1:.*]] = ntensor.to_tensor_copy %[[ARG]] : !ntensor.ntensor<?x5xf32> to tensor<?x5xf32>
 //  CHECK-NEXT:   %[[D:.*]] = tensor.dim %[[T1]], %[[C0]] : tensor<?x5xf32>
 //  CHECK-NEXT:   %[[E:.*]] = tensor.empty(%[[D]]) : tensor<?x5xf32>
 //  CHECK-NEXT:   %[[T2:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[T1]] : tensor<?x5xf32>) outs(%[[E]] : tensor<?x5xf32>) {
@@ -141,7 +141,7 @@ func.func @test(%arg1: !ntensor.ntensor<?x5xf32, "test">) -> !ntensor.ntensor<?x
 //  CHECK-SAME:   (%[[ARG:.*]]: !ntensor.ntensor<?x5xf32, "test">)
 //  CHECK-NEXT:   %[[C0:.*]] = arith.constant 0 : index
 //  CHECK-NEXT:   %[[T0:.*]] = numba_util.env_region "test" -> !ntensor.ntensor<?x5xf32, "test"> {
-//  CHECK-NEXT:   %[[T1:.*]] = ntensor.to_tensor %[[ARG]] : !ntensor.ntensor<?x5xf32, "test"> to tensor<?x5xf32>
+//  CHECK-NEXT:   %[[T1:.*]] = ntensor.to_tensor_copy %[[ARG]] : !ntensor.ntensor<?x5xf32, "test"> to tensor<?x5xf32>
 //  CHECK-NEXT:   %[[D:.*]] = tensor.dim %[[T1]], %[[C0]] : tensor<?x5xf32>
 //  CHECK-NEXT:   %[[E:.*]] = tensor.empty(%[[D]]) : tensor<?x5xf32>
 //  CHECK-NEXT:   %[[T2:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[T1]] : tensor<?x5xf32>) outs(%[[E]] : tensor<?x5xf32>) {
@@ -162,7 +162,7 @@ func.func @test(%arg1: !ntensor.ntensor<?xf32>) -> !ntensor.ntensor<5xf32> {
 }
 // CHECK-LABEL: func @test
 //  CHECK-SAME:   (%[[ARG:.*]]: !ntensor.ntensor<?xf32>)
-//  CHECK-NEXT:   %[[VAL1:.*]] = ntensor.to_tensor %[[ARG]] : !ntensor.ntensor<?xf32> to tensor<?xf32>
+//  CHECK-NEXT:   %[[VAL1:.*]] = ntensor.to_tensor_copy %[[ARG]] : !ntensor.ntensor<?xf32> to tensor<?xf32>
 //  CHECK-NEXT:   %[[VAL2:.*]] = tensor.cast %[[VAL1]] : tensor<?xf32> to tensor<5xf32>
 //  CHECK-NEXT:   %[[VAL3:.*]] = ntensor.from_tensor %[[VAL2]] : tensor<5xf32> to !ntensor.ntensor<5xf32>
 //  CHECK-NEXT:   return %[[VAL3]] : !ntensor.ntensor<5xf32>
@@ -176,7 +176,7 @@ func.func @test(%arg1: !ntensor.ntensor<?xf32, "test">) -> !ntensor.ntensor<5xf3
 // CHECK-LABEL: func @test
 //  CHECK-SAME:   (%[[ARG:.*]]: !ntensor.ntensor<?xf32, "test">)
 //  CHECK-NEXT:   %[[RES:.*]] = numba_util.env_region "test" -> !ntensor.ntensor<5xf32, "test"> {
-//  CHECK-NEXT:   %[[VAL1:.*]] = ntensor.to_tensor %[[ARG]] : !ntensor.ntensor<?xf32, "test"> to tensor<?xf32>
+//  CHECK-NEXT:   %[[VAL1:.*]] = ntensor.to_tensor_copy %[[ARG]] : !ntensor.ntensor<?xf32, "test"> to tensor<?xf32>
 //  CHECK-NEXT:   %[[VAL2:.*]] = tensor.cast %[[VAL1]] : tensor<?xf32> to tensor<5xf32>
 //  CHECK-NEXT:   %[[VAL3:.*]] = ntensor.from_tensor %[[VAL2]] : tensor<5xf32> to !ntensor.ntensor<5xf32, "test">
 //  CHECK-NEXT:   numba_util.env_region_yield %[[VAL3]] : !ntensor.ntensor<5xf32, "test">
@@ -266,7 +266,7 @@ func.func @test(%arg1: !ntensor.ntensor<?xf32>) -> f32 {
 // CHECK-LABEL: func @test
 //  CHECK-SAME:   (%[[ARG:.*]]: !ntensor.ntensor<?xf32>)
 //  CHECK-NEXT:   %[[IND:.*]] = arith.constant 0 : index
-//  CHECK-NEXT:   %[[T1:.*]] = ntensor.to_tensor %[[ARG]] : !ntensor.ntensor<?xf32> to tensor<?xf32>
+//  CHECK-NEXT:   %[[T1:.*]] = ntensor.to_tensor_copy %[[ARG]] : !ntensor.ntensor<?xf32> to tensor<?xf32>
 //  CHECK-NEXT:   %[[RES:.*]] = tensor.extract %[[T1]][%[[IND]]] : tensor<?xf32>
 //  CHECK-NEXT:   return %[[RES]] : f32
 
@@ -281,7 +281,7 @@ func.func @test(%arg1: !ntensor.ntensor<?xf32, "test">) -> f32 {
 //  CHECK-SAME:   (%[[ARG:.*]]: !ntensor.ntensor<?xf32, "test">)
 //  CHECK-NEXT:   %[[IND:.*]] = arith.constant 0 : index
 //  CHECK-NEXT:   %[[RES:.*]] = numba_util.env_region "test" -> f32 {
-//  CHECK-NEXT:   %[[T1:.*]] = ntensor.to_tensor %[[ARG]] : !ntensor.ntensor<?xf32, "test"> to tensor<?xf32>
+//  CHECK-NEXT:   %[[T1:.*]] = ntensor.to_tensor_copy %[[ARG]] : !ntensor.ntensor<?xf32, "test"> to tensor<?xf32>
 //  CHECK-NEXT:   %[[T2:.*]] = tensor.extract %[[T1]][%[[IND]]] : tensor<?xf32>
 //  CHECK-NEXT:   numba_util.env_region_yield %[[T2]] : f32
 //  CHECK-NEXT:   }
@@ -328,8 +328,8 @@ func.func @test(%arg1: !ntensor.ntensor<?x?xf32>, %arg2: !ntensor.ntensor<?x?xf3
 }
 // CHECK-LABEL: func @test
 //  CHECK-SAME:   (%[[ARG1:.*]]: !ntensor.ntensor<?x?xf32>, %[[ARG2:.*]]: !ntensor.ntensor<?x?xf32>)
-//       CHECK:   %[[SRC1:.*]] = ntensor.to_tensor %[[ARG1]] : !ntensor.ntensor<?x?xf32> to tensor<?x?xf32>
-//       CHECK:   %[[SRC2:.*]] = ntensor.to_tensor %[[ARG2]] : !ntensor.ntensor<?x?xf32> to tensor<?x?xf32>
+//       CHECK:   %[[SRC1:.*]] = ntensor.to_tensor_copy %[[ARG1]] : !ntensor.ntensor<?x?xf32> to tensor<?x?xf32>
+//       CHECK:   %[[SRC2:.*]] = ntensor.to_tensor_copy %[[ARG2]] : !ntensor.ntensor<?x?xf32> to tensor<?x?xf32>
 
 //       CHECK:   %[[SRC1D1:.*]] = scf.if %{{.*}} -> (tensor<?x?xf32>) {
 //       CHECK:     %[[TMP1:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?xf32>
@@ -388,8 +388,8 @@ func.func @test(%arg1: !ntensor.ntensor<?x?xf32>, %arg2: !ntensor.ntensor<?xf32>
 }
 // CHECK-LABEL: func @test
 //  CHECK-SAME:   (%[[ARG1:.*]]: !ntensor.ntensor<?x?xf32>, %[[ARG2:.*]]: !ntensor.ntensor<?xf32>)
-//       CHECK:   %[[SRC1:.*]] = ntensor.to_tensor %[[ARG1]] : !ntensor.ntensor<?x?xf32> to tensor<?x?xf32>
-//       CHECK:   %[[SRC2:.*]] = ntensor.to_tensor %[[ARG2]] : !ntensor.ntensor<?xf32> to tensor<?xf32>
+//       CHECK:   %[[SRC1:.*]] = ntensor.to_tensor_copy %[[ARG1]] : !ntensor.ntensor<?x?xf32> to tensor<?x?xf32>
+//       CHECK:   %[[SRC2:.*]] = ntensor.to_tensor_copy %[[ARG2]] : !ntensor.ntensor<?xf32> to tensor<?xf32>
 
 //       CHECK:   %[[SRC1D1:.*]] = scf.if %{{.*}} -> (tensor<?x?xf32>) {
 //       CHECK:     %[[TMP1:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?xf32>
@@ -442,8 +442,8 @@ func.func @test(%arg1: !ntensor.ntensor<?x?xf32>, %arg2: !ntensor.ntensor<f32>) 
 }
 // CHECK-LABEL: func @test
 //  CHECK-SAME:   (%[[ARG1:.*]]: !ntensor.ntensor<?x?xf32>, %[[ARG2:.*]]: !ntensor.ntensor<f32>)
-//       CHECK:   %[[SRC1:.*]] = ntensor.to_tensor %[[ARG1]] : !ntensor.ntensor<?x?xf32> to tensor<?x?xf32>
-//       CHECK:   %[[SRC2:.*]] = ntensor.to_tensor %[[ARG2]] : !ntensor.ntensor<f32> to tensor<f32>
+//       CHECK:   %[[SRC1:.*]] = ntensor.to_tensor_copy %[[ARG1]] : !ntensor.ntensor<?x?xf32> to tensor<?x?xf32>
+//       CHECK:   %[[SRC2:.*]] = ntensor.to_tensor_copy %[[ARG2]] : !ntensor.ntensor<f32> to tensor<f32>
 
 //       CHECK:   %[[SRC1D1:.*]] = scf.if %{{.*}} -> (tensor<?x?xf32>) {
 //       CHECK:     %[[TMP1:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?xf32>
@@ -485,8 +485,8 @@ func.func @test(%arg1: !ntensor.ntensor<?x?xf32, "test">, %arg2: !ntensor.ntenso
 // CHECK-LABEL: func @test
 //  CHECK-SAME:   (%[[ARG1:.*]]: !ntensor.ntensor<?x?xf32, "test">, %[[ARG2:.*]]: !ntensor.ntensor<f32, "test">)
 //       CHECK:   %[[RET:.*]]:2 = numba_util.env_region "test" -> !ntensor.ntensor<?x?xf32, "test">, !ntensor.ntensor<?x?xf32, "test"> {
-//       CHECK:   %[[SRC1:.*]] = ntensor.to_tensor %[[ARG1]] : !ntensor.ntensor<?x?xf32, "test"> to tensor<?x?xf32>
-//       CHECK:   %[[SRC2:.*]] = ntensor.to_tensor %[[ARG2]] : !ntensor.ntensor<f32, "test"> to tensor<f32>
+//       CHECK:   %[[SRC1:.*]] = ntensor.to_tensor_copy %[[ARG1]] : !ntensor.ntensor<?x?xf32, "test"> to tensor<?x?xf32>
+//       CHECK:   %[[SRC2:.*]] = ntensor.to_tensor_copy %[[ARG2]] : !ntensor.ntensor<f32, "test"> to tensor<f32>
 
 //       CHECK:   %[[SRC1D1:.*]] = scf.if %{{.*}} -> (tensor<?x?xf32>) {
 //       CHECK:     %[[TMP1:.*]] = tensor.empty(%{{.*}}, %{{.*}}) : tensor<?x?xf32>

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/PyLinalgResolver.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/PyLinalgResolver.cpp
@@ -239,7 +239,8 @@ static mlir::Value doCast(mlir::OpBuilder &builder, mlir::Location loc,
 
   if (srcType.isa<numba::ntensor::NTensorType>() &&
       dstType.isa<mlir::RankedTensorType>())
-    return builder.createOrFold<numba::ntensor::ToTensorOp>(loc, dstType, val);
+    return builder.createOrFold<numba::ntensor::ToTensorCopyOp>(loc, dstType,
+                                                                val);
 
   if (srcType.isa<numba::ntensor::NTensorType>() &&
       dstType.isa<numba::ntensor::NTensorType>())
@@ -457,7 +458,7 @@ static mlir::Value toTensor(mlir::Location loc, mlir::OpBuilder &builder,
   if (auto ntensorType = srcType.dyn_cast<numba::ntensor::NTensorType>()) {
     auto tensorType = mlir::RankedTensorType::get(ntensorType.getShape(),
                                                   ntensorType.getElementType());
-    return builder.create<numba::ntensor::ToTensorOp>(loc, tensorType, val);
+    return builder.create<numba::ntensor::ToTensorCopyOp>(loc, tensorType, val);
   }
 
   return val;

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -4560,7 +4560,7 @@ static void populatePlierToLinalgGenPipeline(mlir::OpPassManager &pm) {
   pm.addNestedPass<mlir::func::FuncOp>(numba::createNtensorToLinalgPass());
   pm.addNestedPass<mlir::func::FuncOp>(
       numba::createNtensorLowerToTensorCopyPass());
-  pm.addNestedPass<mlir::func::FuncOp>(numba::ntensor::createCopyRemovalPass());
+  pm.addNestedPass<mlir::func::FuncOp>(numba::createCopyRemovalPass());
   pm.addPass(std::make_unique<MarkInputShapesRanges>());
   pm.addPass(numba::createCompositePass(
       "PostPlierToLinalgPass", [](mlir::OpPassManager &p) {

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -1322,7 +1322,8 @@ static std::optional<mlir::Value> doCast(mlir::OpBuilder &builder,
     } else if (dstShapedType.isa<mlir::RankedTensorType>()) {
       auto dstTensorType = mlir::RankedTensorType::get(
           srcArrayType.getShape(), dstShapedType.getElementType());
-      res = builder.create<numba::ntensor::ToTensorOp>(loc, dstTensorType, res);
+      res = builder.create<numba::ntensor::ToTensorCopyOp>(loc, dstTensorType,
+                                                           res);
     }
 
     return castType(builder, loc, res, dstShapedType);

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/PlierToLinalg.cpp
@@ -4558,6 +4558,9 @@ static void populatePlierToLinalgGenPipeline(mlir::OpPassManager &pm) {
   pm.addPass(mlir::createCanonicalizerPass());
   pm.addNestedPass<mlir::func::FuncOp>(numba::createNtensorAliasAnalysisPass());
   pm.addNestedPass<mlir::func::FuncOp>(numba::createNtensorToLinalgPass());
+  pm.addNestedPass<mlir::func::FuncOp>(
+      numba::createNtensorLowerToTensorCopyPass());
+  pm.addNestedPass<mlir::func::FuncOp>(numba::ntensor::createCopyRemovalPass());
   pm.addPass(std::make_unique<MarkInputShapesRanges>());
   pm.addPass(numba::createCompositePass(
       "PostPlierToLinalgPass", [](mlir::OpPassManager &p) {


### PR DESCRIPTION
* Instead of doing ad-hoc alias analysis on tensors (which is dubious thing to begin with) in various places, introduce `ntensor.to_tensor_copy` in addition to `ntensor.to_tensor`.  `ntensor.to_tensor_copy` is always lowered to memref copy
* Do an alias analysis in signle `NtensorLowerToTensorCopyPass`, which checks in there are no writes to `to_tensor_copy` arg and convert it to `to_tensor` if possible, which is then lowered to no-op in tensor land.
* Various cleanups

