### PR TITLE
Add `math_ext` dialect

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -28,6 +28,7 @@ add_subdirectory(include/numba/Dialect/plier)
 add_subdirectory(include/numba/Dialect/numba_util)
 add_subdirectory(include/numba/Dialect/gpu_runtime/IR)
 add_subdirectory(include/numba/Dialect/ntensor/IR)
+add_subdirectory(include/numba/Dialect/math_ext/IR)
 
 set(SOURCES_LIST
     lib/Analysis/AliasAnalysis.cpp
@@ -46,6 +47,8 @@ set(SOURCES_LIST
     lib/Conversion/UtilToLlvm.cpp
     lib/Dialect/gpu_runtime/IR/GpuRuntimeOps.cpp
     lib/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.cpp
+    lib/Dialect/math_ext/IR/MathExtDialect.cpp
+    lib/Dialect/math_ext/IR/MathExtOps.cpp
     lib/Dialect/ntensor/IR/NTensorOps.cpp
     lib/Dialect/ntensor/Transforms/PropagateEnvironment.cpp
     lib/Dialect/ntensor/Transforms/ResolveArrayOps.cpp
@@ -58,8 +61,8 @@ set(SOURCES_LIST
     lib/Transforms/CastUtils.cpp
     lib/Transforms/CommonOpts.cpp
     lib/Transforms/CompositePass.cpp
-    lib/Transforms/CopyRemoval.cpp
     lib/Transforms/ConstUtils.cpp
+    lib/Transforms/CopyRemoval.cpp
     lib/Transforms/ExpandTuple.cpp
     lib/Transforms/FuncTransforms.cpp
     lib/Transforms/FuncUtils.cpp
@@ -96,6 +99,7 @@ set(HEADERS_LIST
     include/numba/Conversion/UtilToLlvm.hpp
     include/numba/Dialect/gpu_runtime/IR/GpuRuntimeOps.hpp
     include/numba/Dialect/gpu_runtime/Transforms/MakeBarriersUniform.hpp
+    include/numba/Dialect/math_ext/IR/MathExt.hpp
     include/numba/Dialect/ntensor/IR/NTensorOps.hpp
     include/numba/Dialect/ntensor/Transforms/PropagateEnvironment.hpp
     include/numba/Dialect/ntensor/Transforms/ResolveArrayOps.hpp
@@ -109,8 +113,8 @@ set(HEADERS_LIST
     include/numba/Transforms/CastUtils.hpp
     include/numba/Transforms/CommonOpts.hpp
     include/numba/Transforms/CompositePass.hpp
-    include/numba/Transforms/CopyRemoval.hpp
     include/numba/Transforms/ConstUtils.hpp
+    include/numba/Transforms/CopyRemoval.hpp
     include/numba/Transforms/ExpandTuple.hpp
     include/numba/Transforms/FuncTransforms.hpp
     include/numba/Transforms/FuncUtils.hpp
@@ -178,7 +182,7 @@ target_include_directories(${NUMBA_MLIR_LIB} PUBLIC
     ${PROJECT_BINARY_DIR}/numba/include
     )
 
-add_dependencies(${NUMBA_MLIR_LIB} MLIRPlierOpsIncGen MLIRNumbaUtilOpsIncGen MLIRGpuRuntimeOpsIncGen MLIRNTensorOpsIncGen)
+add_dependencies(${NUMBA_MLIR_LIB} MLIRPlierOpsIncGen MLIRNumbaUtilOpsIncGen MLIRGpuRuntimeOpsIncGen MLIRNTensorOpsIncGen MLIRMathExtOpsIncGen)
 
 add_subdirectory(tools)
 if(NUMBA_MLIR_ENABLE_TESTS)

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SOURCES_LIST
     lib/Conversion/DecomposeMemrefs.cpp
     lib/Conversion/GpuRuntimeToLlvm.cpp
     lib/Conversion/GpuToGpuRuntime.cpp
+    lib/Conversion/MathExtToLibm.cpp
     lib/Conversion/NtensorToLinalg.cpp
     lib/Conversion/NtensorToMemref.cpp
     lib/Conversion/SCFToAffine/SCFToAffine.cpp
@@ -92,6 +93,7 @@ set(HEADERS_LIST
     include/numba/Conversion/CfgToScf.hpp
     include/numba/Conversion/GpuRuntimeToLlvm.hpp
     include/numba/Conversion/GpuToGpuRuntime.hpp
+    include/numba/Conversion/MathExtToLibm.hpp
     include/numba/Conversion/NtensorToLinalg.hpp
     include/numba/Conversion/NtensorToMemref.hpp
     include/numba/Conversion/SCFToAffine/SCFToAffine.h

--- a/mlir/include/numba/Conversion/MathExtToLibm.hpp
+++ b/mlir/include/numba/Conversion/MathExtToLibm.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <memory>
+
+namespace mlir {
+class Pass;
+class RewritePatternSet;
+} // namespace mlir
+
+namespace numba {
+void populateMathExtToLibmPatterns(mlir::RewritePatternSet &patterns);
+
+std::unique_ptr<mlir::Pass> createMathExtToLibmPass();
+} // namespace numba

--- a/mlir/include/numba/Dialect/math_ext/IR/CMakeLists.txt
+++ b/mlir/include/numba/Dialect/math_ext/IR/CMakeLists.txt
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+include_directories(${MLIR_INCLUDE_DIRS})
+set(dialect MathExtOps)
+set(dialect_namespace math_ext)
+set(LLVM_TARGET_DEFINITIONS ${dialect}.td)
+# mlir_tablegen(${dialect}Enums.h.inc -gen-enum-decls)
+# mlir_tablegen(${dialect}Enums.cpp.inc -gen-enum-defs)
+# mlir_tablegen(${dialect}Attributes.h.inc -gen-attrdef-decls -attrdefs-dialect=${dialect_namespace})
+# mlir_tablegen(${dialect}Attributes.cpp.inc -gen-attrdef-defs -attrdefs-dialect=${dialect_namespace})
+mlir_tablegen(${dialect}.h.inc -gen-op-decls)
+mlir_tablegen(${dialect}.cpp.inc -gen-op-defs)
+mlir_tablegen(${dialect}Dialect.h.inc -gen-dialect-decls -dialect=${dialect_namespace})
+mlir_tablegen(${dialect}Dialect.cpp.inc -gen-dialect-defs -dialect=${dialect_namespace})
+# mlir_tablegen(${dialect}Types.h.inc -gen-typedef-decls)
+# mlir_tablegen(${dialect}Types.cpp.inc -gen-typedef-defs)
+add_public_tablegen_target(MLIR${dialect}IncGen)
+add_dependencies(mlir-headers MLIR${dialect}IncGen)

--- a/mlir/include/numba/Dialect/math_ext/IR/MathExt.hpp
+++ b/mlir/include/numba/Dialect/math_ext/IR/MathExt.hpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <mlir/Bytecode/BytecodeOpInterface.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/IR/BuiltinTypes.h>
+#include <mlir/IR/Dialect.h>
+#include <mlir/IR/OpDefinition.h>
+#include <mlir/IR/OpImplementation.h>
+#include <mlir/Interfaces/InferTypeOpInterface.h>
+#include <mlir/Interfaces/SideEffectInterfaces.h>
+#include <mlir/Interfaces/VectorInterfaces.h>
+
+//===----------------------------------------------------------------------===//
+// Math Dialect
+//===----------------------------------------------------------------------===//
+
+#include "numba/Dialect/math_ext/IR/MathExtOpsDialect.h.inc"
+
+//===----------------------------------------------------------------------===//
+// Math Dialect Operations
+//===----------------------------------------------------------------------===//
+
+#define GET_OP_CLASSES
+#include "numba/Dialect/math_ext/IR/MathExtOps.h.inc"

--- a/mlir/include/numba/Dialect/math_ext/IR/MathExtBase.td
+++ b/mlir/include/numba/Dialect/math_ext/IR/MathExtBase.td
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef MATH_EXT_BASE
+#define MATH_EXT_BASE
+include "mlir/IR/OpBase.td"
+def MathExt_Dialect : Dialect {
+  let name = "math_ext";
+  let cppNamespace = "::numba::math_ext";
+  let description = [{
+    Extensions to math dialect
+
+    The math dialect is intended to hold mathematical operations on integer and
+    floating types beyond simple arithmetics. Each operation works on scalar, vector
+    or tensor type. On vector and tensor type operations apply elementwise unless
+    explicitly specified otherwise. As an example, the floating point absolute value
+    can be expressed as:
+
+    ```mlir
+    // Scalar absolute value.
+    %a = math.absf %b : f64
+
+    // Vector elementwise absolute value.
+    %f = math.absf %g : vector<4xf32>
+
+    // Tensor elementwise absolute value.
+    %x = math.absf %y : tensor<4x?xf8>
+    ```
+  }];
+  let hasConstantMaterializer = 1;
+  let dependentDialects = [
+    "::mlir::arith::ArithDialect"
+  ];
+}
+#endif // MATH_EXT_BASE

--- a/mlir/include/numba/Dialect/math_ext/IR/MathExtOps.td
+++ b/mlir/include/numba/Dialect/math_ext/IR/MathExtOps.td
@@ -1,0 +1,107 @@
+//===- MathOps.td - Math op definitions --------------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MATH_EXT_OPS
+#define MATH_EXT_OPS
+
+include "MathExtBase.td"
+
+include "mlir/Dialect/Arith/IR/ArithBase.td"
+include "mlir/Dialect/Arith/IR/ArithOpsInterfaces.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/VectorInterfaces.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+// Base class for math dialect ops. Ops in this dialect have no side effects and
+// can be applied element-wise to vectors and tensors.
+class MathExt_Op<string mnemonic, list<Trait> traits = []> :
+    Op<MathExt_Dialect, mnemonic, traits # [Pure,
+    DeclareOpInterfaceMethods<VectorUnrollOpInterface>] #
+    ElementwiseMappable.traits>;
+
+// Base class for unary math operations on integer types. Require an operand
+// and result of the same type. This type can be an integer type, vector or
+// tensor thereof.
+class MathExt_IntegerUnaryOp<string mnemonic, list<Trait> traits = []> :
+    MathExt_Op<mnemonic, traits # [SameOperandsAndResultType]> {
+  let arguments = (ins SignlessIntegerLike:$operand);
+  let results = (outs SignlessIntegerLike:$result);
+
+  let assemblyFormat = "$operand attr-dict `:` type($result)";
+}
+
+// Base class for unary math operations on floating point types. Require an
+// operand and result of the same type. This type can be a floating point type,
+// vector or tensor thereof.
+class MathExt_FloatUnaryOp<string mnemonic, list<Trait> traits = []> :
+    MathExt_Op<mnemonic,
+        traits # [SameOperandsAndResultType,
+                  DeclareOpInterfaceMethods<ArithFastMathInterface>]> {
+  let arguments = (ins FloatLike:$operand,
+      DefaultValuedAttr<Arith_FastMathAttr,
+                        "::mlir::arith::FastMathFlags::none">:$fastmath);
+  let results = (outs FloatLike:$result);
+
+  let assemblyFormat = [{ $operand (`fastmath` `` $fastmath^)?
+                          attr-dict `:` type($result) }];
+}
+
+// Base class for binary math operations on integer types. Require two
+// operands and one result of the same type. This type can be an integer
+// type, vector or tensor thereof.
+class MathExt_IntegerBinaryOp<string mnemonic, list<Trait> traits = []> :
+    MathExt_Op<mnemonic, traits # [SameOperandsAndResultType]> {
+  let arguments = (ins SignlessIntegerLike:$lhs, SignlessIntegerLike:$rhs);
+  let results = (outs SignlessIntegerLike:$result);
+
+  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($result)";
+}
+
+// Base class for binary math operations on floating point types. Require two
+// operands and one result of the same type. This type can be a floating point
+// type, vector or tensor thereof.
+class MathExt_FloatBinaryOp<string mnemonic, list<Trait> traits = []> :
+    MathExt_Op<mnemonic,
+        traits # [SameOperandsAndResultType,
+                  DeclareOpInterfaceMethods<ArithFastMathInterface>]> {
+  let arguments = (ins FloatLike:$lhs, FloatLike:$rhs,
+      DefaultValuedAttr<Arith_FastMathAttr,
+                        "::mlir::arith::FastMathFlags::none">:$fastmath);
+  let results = (outs FloatLike:$result);
+
+  let assemblyFormat = [{ $lhs `,` $rhs (`fastmath` `` $fastmath^)?
+                          attr-dict `:` type($result) }];
+}
+
+// Base class for floating point ternary operations. Require three operands and
+// one result of the same type. This type can be a floating point type, vector
+// or tensor thereof.
+class MathExt_FloatTernaryOp<string mnemonic, list<Trait> traits = []> :
+    MathExt_Op<mnemonic,
+        traits # [SameOperandsAndResultType,
+                  DeclareOpInterfaceMethods<ArithFastMathInterface>]> {
+  let arguments = (ins FloatLike:$a, FloatLike:$b, FloatLike:$c,
+      DefaultValuedAttr<Arith_FastMathAttr,
+                        "::mlir::arith::FastMathFlags::none">:$fastmath);
+  let results = (outs FloatLike:$result);
+
+  let assemblyFormat = [{ $a `,` $b `,` $c (`fastmath` `` $fastmath^)?
+                          attr-dict `:` type($result) }];
+}
+
+//===----------------------------------------------------------------------===//
+// AcosOp
+//===----------------------------------------------------------------------===//
+
+def MathExt_AcosOp : MathExt_FloatUnaryOp<"acos"> {
+
+  let hasFolder = 1;
+}
+
+
+#endif // MATH_EXT_OPS

--- a/mlir/lib/Conversion/MathExtToLibm.cpp
+++ b/mlir/lib/Conversion/MathExtToLibm.cpp
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "numba/Conversion/MathExtToLibm.hpp"
+
+#include "numba/Dialect/math_ext/IR/MathExt.hpp"
+
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/LLVMIR/LLVMDialect.h>
+#include <mlir/Dialect/Utils/IndexingUtils.h>
+#include <mlir/Dialect/Vector/IR/VectorOps.h>
+#include <mlir/IR/BuiltinDialect.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/Pass/Pass.h>
+#include <mlir/Transforms/DialectConversion.h>
+
+namespace {
+// Pattern to convert vector operations to scalar operations. This is needed as
+// libm calls require scalars.
+template <typename Op>
+struct VecOpToScalarOp : public mlir::OpRewritePattern<Op> {
+public:
+  using mlir::OpRewritePattern<Op>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(Op op, mlir::PatternRewriter &rewriter) const final {
+    auto opType = op.getType();
+    auto loc = op.getLoc();
+    auto vecType = mlir::dyn_cast<mlir::VectorType>(opType);
+
+    if (!vecType)
+      return mlir::failure();
+    if (!vecType.hasRank())
+      return mlir::failure();
+    auto shape = vecType.getShape();
+    int64_t numElements = vecType.getNumElements();
+
+    mlir::Value result = rewriter.create<mlir::arith::ConstantOp>(
+        loc, mlir::DenseElementsAttr::get(
+                 vecType, mlir::FloatAttr::get(vecType.getElementType(), 0.0)));
+    mlir::SmallVector<int64_t> strides = mlir::computeStrides(shape);
+    for (auto linearIndex = 0; linearIndex < numElements; ++linearIndex) {
+      mlir::SmallVector<int64_t> positions =
+          mlir::delinearize(linearIndex, strides);
+      mlir::SmallVector<mlir::Value> operands;
+      for (auto input : op->getOperands())
+        operands.push_back(
+            rewriter.create<mlir::vector::ExtractOp>(loc, input, positions));
+      mlir::Value scalarOp =
+          rewriter.create<Op>(loc, vecType.getElementType(), operands);
+      result = rewriter.create<mlir::vector::InsertOp>(loc, scalarOp, result,
+                                                       positions);
+    }
+    rewriter.replaceOp(op, {result});
+    return mlir::success();
+  }
+};
+
+template <typename Op>
+struct PromoteOpToF32 : public mlir::OpRewritePattern<Op> {
+public:
+  using mlir::OpRewritePattern<Op>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(Op op, mlir::PatternRewriter &rewriter) const final {
+    auto opType = op.getType();
+    if (!mlir::isa<mlir::Float16Type, mlir::BFloat16Type>(opType))
+      return mlir::failure();
+
+    auto loc = op.getLoc();
+    auto f32 = rewriter.getF32Type();
+    auto extendedOperands = llvm::to_vector(llvm::map_range(
+        op->getOperands(), [&](mlir::Value operand) -> mlir::Value {
+          return rewriter.create<mlir::arith::ExtFOp>(loc, f32, operand);
+        }));
+    auto newOp = rewriter.create<Op>(loc, f32, extendedOperands);
+    rewriter.replaceOpWithNewOp<mlir::arith::TruncFOp>(op, opType, newOp);
+    return mlir::success();
+  }
+};
+
+template <typename Op>
+struct ScalarOpToLibmCall : public mlir::OpRewritePattern<Op> {
+public:
+  using mlir::OpRewritePattern<Op>::OpRewritePattern;
+  ScalarOpToLibmCall(mlir::MLIRContext *context, mlir::StringRef floatFunc,
+                     mlir::StringRef doubleFunc)
+      : mlir::OpRewritePattern<Op>(context), floatFunc(floatFunc),
+        doubleFunc(doubleFunc){};
+
+  mlir::LogicalResult
+  matchAndRewrite(Op op, mlir::PatternRewriter &rewriter) const final {
+    auto module = mlir::SymbolTable::getNearestSymbolTable(op);
+    auto type = op.getType();
+    if (!mlir::isa<mlir::Float32Type, mlir::Float64Type>(type))
+      return mlir::failure();
+
+    auto name = type.getIntOrFloatBitWidth() == 64 ? doubleFunc : floatFunc;
+    auto opFunc = mlir::dyn_cast_or_null<mlir::SymbolOpInterface>(
+        mlir::SymbolTable::lookupSymbolIn(module, name));
+    // Forward declare function if it hasn't already been
+    if (!opFunc) {
+      mlir::OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(&module->getRegion(0).front());
+      auto opFunctionTy = mlir::FunctionType::get(
+          rewriter.getContext(), op->getOperandTypes(), op->getResultTypes());
+      opFunc = rewriter.create<mlir::func::FuncOp>(rewriter.getUnknownLoc(),
+                                                   name, opFunctionTy);
+      opFunc.setPrivate();
+
+      // By definition Math dialect operations imply LLVM's "readnone"
+      // function attribute, so we can set it here to provide more
+      // optimization opportunities (e.g. LICM) for backends targeting LLVM IR.
+      // This will have to be changed, when strict FP behavior is supported
+      // by Math dialect.
+      opFunc->setAttr(mlir::LLVM::LLVMDialect::getReadnoneAttrName(),
+                      mlir::UnitAttr::get(rewriter.getContext()));
+    }
+    assert(mlir::isa<mlir::FunctionOpInterface>(
+        mlir::SymbolTable::lookupSymbolIn(module, name)));
+
+    rewriter.replaceOpWithNewOp<mlir::func::CallOp>(op, name, op.getType(),
+                                                    op->getOperands());
+
+    return mlir::success();
+  }
+
+private:
+  std::string floatFunc, doubleFunc;
+};
+
+template <typename OpTy>
+static void
+populatePatternsForOp(mlir::RewritePatternSet &patterns, mlir::MLIRContext *ctx,
+                      mlir::StringRef floatFunc, mlir::StringRef doubleFunc) {
+  patterns.add<VecOpToScalarOp<OpTy>, PromoteOpToF32<OpTy>>(ctx);
+  patterns.add<ScalarOpToLibmCall<OpTy>>(ctx, floatFunc, doubleFunc);
+}
+
+struct MathExtToLibmPass
+    : public mlir::PassWrapper<MathExtToLibmPass, mlir::OperationPass<void>> {
+
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MathExtToLibmPass)
+
+  void runOnOperation() override {
+    auto op = getOperation();
+
+    mlir::RewritePatternSet patterns(&getContext());
+    numba::populateMathExtToLibmPatterns(patterns);
+
+    mlir::ConversionTarget target(getContext());
+    target.addLegalDialect<mlir::arith::ArithDialect, mlir::BuiltinDialect,
+                           mlir::func::FuncDialect,
+                           mlir::vector::VectorDialect>();
+    target.addIllegalDialect<numba::math_ext::MathExtDialect>();
+    if (failed(applyPartialConversion(op, target, std::move(patterns))))
+      signalPassFailure();
+  }
+};
+} // namespace
+
+void numba::populateMathExtToLibmPatterns(mlir::RewritePatternSet &patterns) {
+  auto *ctx = patterns.getContext();
+
+  populatePatternsForOp<numba::math_ext::AcosOp>(patterns, ctx, "acosf",
+                                                 "acos");
+}
+
+std::unique_ptr<mlir::Pass> numba::createMathExtToLibmPass() {
+  return std::make_unique<MathExtToLibmPass>();
+}

--- a/mlir/lib/Dialect/math_ext/IR/MathExtDialect.cpp
+++ b/mlir/lib/Dialect/math_ext/IR/MathExtDialect.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-
 #include "numba/Dialect/math_ext/IR/MathExt.hpp"
 
 #include "mlir/Transforms/InliningUtils.h"
@@ -16,7 +15,8 @@ struct MathExtInlinerInterface : public mlir::DialectInlinerInterface {
   using DialectInlinerInterface::DialectInlinerInterface;
 
   /// All operations within math ops can be inlined.
-  bool isLegalToInline(mlir::Operation *, mlir::Region *, bool, mlir::IRMapping &) const final {
+  bool isLegalToInline(mlir::Operation *, mlir::Region *, bool,
+                       mlir::IRMapping &) const final {
     return true;
   }
 };

--- a/mlir/lib/Dialect/math_ext/IR/MathExtDialect.cpp
+++ b/mlir/lib/Dialect/math_ext/IR/MathExtDialect.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+#include "numba/Dialect/math_ext/IR/MathExt.hpp"
+
+#include "mlir/Transforms/InliningUtils.h"
+
+#include "numba/Dialect/math_ext/IR/MathExtOpsDialect.cpp.inc"
+
+namespace {
+/// This class defines the interface for handling inlining with math
+/// operations.
+struct MathExtInlinerInterface : public mlir::DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+
+  /// All operations within math ops can be inlined.
+  bool isLegalToInline(mlir::Operation *, mlir::Region *, bool, mlir::IRMapping &) const final {
+    return true;
+  }
+};
+} // namespace
+
+void numba::math_ext::MathExtDialect::initialize() {
+  addOperations<
+#define GET_OP_LIST
+#include "numba/Dialect/math_ext/IR/MathExtOps.cpp.inc"
+      >();
+  addInterfaces<MathExtInlinerInterface>();
+}

--- a/mlir/lib/Dialect/math_ext/IR/MathExtOps.cpp
+++ b/mlir/lib/Dialect/math_ext/IR/MathExtOps.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "numba/Dialect/math_ext/IR/MathExt.hpp"
+
+#include <mlir/Dialect/Arith/IR/Arith.h>
+#include <mlir/Dialect/CommonFolders.h>
+#include <mlir/Dialect/Math/IR/Math.h>
+#include <mlir/Dialect/UB/IR/UBOps.h>
+#include <mlir/IR/Builders.h>
+#include <optional>
+
+//===----------------------------------------------------------------------===//
+// TableGen'd op method definitions
+//===----------------------------------------------------------------------===//
+
+#define GET_OP_CLASSES
+#include "numba/Dialect/math_ext/IR/MathExtOps.cpp.inc"
+
+
+/// Materialize an integer or floating point constant.
+mlir::Operation *numba::math_ext::MathExtDialect::materializeConstant(mlir::OpBuilder &builder,
+                                                  mlir::Attribute value, mlir::Type type,
+                                                  mlir::Location loc) {
+  if (auto poison = mlir::dyn_cast<mlir::ub::PoisonAttr>(value))
+    return builder.create<mlir::ub::PoisonOp>(loc, type, poison);
+
+  return mlir::arith::ConstantOp::materialize(builder, value, type, loc);
+}
+
+template<typename Folder>
+static std::optional<mlir::APFloat> foldUnary(mlir::ValueRange args) {
+  return mlir::constFoldUnaryOpConditional<mlir::FloatAttr>(
+      args, [](const mlir::APFloat &a) -> std::optional<mlir::APFloat> {
+        switch (a.getSizeInBits(a.getSemantics())) {
+        case 64:
+          return mlir::APFloat(Folder()(a.convertToDouble()));
+        case 32:
+          return mlir::APFloat(Folder()(a.convertToFloat()));
+        default:
+          return {};
+        }
+      });
+}
+
+#define MAKE_FOLDER(func) struct Folder { auto operator()(auto arg) { return func(arg); } }; return foldUnary<Folder>(adaptor.getOperands());
+
+mlir::OpFoldResult numba::math_ext::AcosOp::fold(numba::math_ext::AcosOp::FoldAdaptor adaptor) {
+  return mlir::constFoldUnaryOpConditional<mlir::FloatAttr>(
+      adaptor.getOperands(), [](const mlir::APFloat &a) -> std::optional<mlir::APFloat> {
+        switch (a.getSizeInBits(a.getSemantics())) {
+        case 64:
+          return mlir::APFloat(atan(a.convertToDouble()));
+        case 32:
+          return mlir::APFloat(atanf(a.convertToFloat()));
+        default:
+          return {};
+        }
+      });
+}

--- a/mlir/lib/Dialect/math_ext/IR/MathExtOps.cpp
+++ b/mlir/lib/Dialect/math_ext/IR/MathExtOps.cpp
@@ -4,6 +4,8 @@
 
 #include "numba/Dialect/math_ext/IR/MathExt.hpp"
 
+#include <cmath>
+
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/CommonFolders.h>
 #include <mlir/Dialect/Math/IR/Math.h>
@@ -18,44 +20,39 @@
 #define GET_OP_CLASSES
 #include "numba/Dialect/math_ext/IR/MathExtOps.cpp.inc"
 
-
 /// Materialize an integer or floating point constant.
-mlir::Operation *numba::math_ext::MathExtDialect::materializeConstant(mlir::OpBuilder &builder,
-                                                  mlir::Attribute value, mlir::Type type,
-                                                  mlir::Location loc) {
+mlir::Operation *numba::math_ext::MathExtDialect::materializeConstant(
+    mlir::OpBuilder &builder, mlir::Attribute value, mlir::Type type,
+    mlir::Location loc) {
   if (auto poison = mlir::dyn_cast<mlir::ub::PoisonAttr>(value))
     return builder.create<mlir::ub::PoisonOp>(loc, type, poison);
 
   return mlir::arith::ConstantOp::materialize(builder, value, type, loc);
 }
 
-template<typename Folder>
-static std::optional<mlir::APFloat> foldUnary(mlir::ValueRange args) {
+template <typename T>
+static mlir::Attribute foldUnary(mlir::ArrayRef<mlir::Attribute> args,
+                                 T &&folder) {
   return mlir::constFoldUnaryOpConditional<mlir::FloatAttr>(
-      args, [](const mlir::APFloat &a) -> std::optional<mlir::APFloat> {
+      args, [&](const mlir::APFloat &a) -> std::optional<mlir::APFloat> {
         switch (a.getSizeInBits(a.getSemantics())) {
         case 64:
-          return mlir::APFloat(Folder()(a.convertToDouble()));
+          return mlir::APFloat(folder(a.convertToDouble()));
         case 32:
-          return mlir::APFloat(Folder()(a.convertToFloat()));
+          return mlir::APFloat(folder(a.convertToFloat()));
         default:
           return {};
         }
       });
 }
 
-#define MAKE_FOLDER(func) struct Folder { auto operator()(auto arg) { return func(arg); } }; return foldUnary<Folder>(adaptor.getOperands());
+#define MAKE_UNARY_FOLDER(func)                                                \
+  auto folder = [](auto arg) { return func(arg); };                            \
+  return foldUnary(adaptor.getOperands(), folder);
 
-mlir::OpFoldResult numba::math_ext::AcosOp::fold(numba::math_ext::AcosOp::FoldAdaptor adaptor) {
-  return mlir::constFoldUnaryOpConditional<mlir::FloatAttr>(
-      adaptor.getOperands(), [](const mlir::APFloat &a) -> std::optional<mlir::APFloat> {
-        switch (a.getSizeInBits(a.getSemantics())) {
-        case 64:
-          return mlir::APFloat(atan(a.convertToDouble()));
-        case 32:
-          return mlir::APFloat(atanf(a.convertToFloat()));
-        default:
-          return {};
-        }
-      });
+mlir::OpFoldResult
+numba::math_ext::AcosOp::fold(numba::math_ext::AcosOp::FoldAdaptor adaptor) {
+  MAKE_UNARY_FOLDER(std::acos);
 }
+
+#undef MAKE_UNARY_FOLDER

--- a/mlir/lib/Transforms/UpliftMath.cpp
+++ b/mlir/lib/Transforms/UpliftMath.cpp
@@ -4,6 +4,8 @@
 
 #include "numba/Transforms/UpliftMath.hpp"
 
+#include "numba/Dialect/math_ext/IR/MathExt.hpp"
+
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Complex/IR/Complex.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
@@ -65,6 +67,7 @@ struct UpliftMathCalls : public mlir::OpRewritePattern<mlir::func::CallOp> {
         {"sin", &replaceOp1<mlir::math::SinOp>},
         {"cos", &replaceOp1<mlir::math::CosOp>},
         {"erf", &replaceOp1<mlir::math::ErfOp>},
+        {"acos", &replaceOp1<numba::math_ext::AcosOp>},
         {"tanh", &replaceOp1<mlir::math::TanhOp>},
         {"atan2", &replaceOp2<mlir::math::Atan2Op>},
     };
@@ -254,6 +257,7 @@ struct UpliftMathPass
     registry.insert<mlir::complex::ComplexDialect>();
     registry.insert<mlir::func::FuncDialect>();
     registry.insert<mlir::math::MathDialect>();
+    registry.insert<numba::math_ext::MathExtDialect>();
   }
 
   void runOnOperation() override {

--- a/numba_mlir/numba_mlir/mlir/builtin/funcs.py
+++ b/numba_mlir/numba_mlir/mlir/builtin/funcs.py
@@ -213,6 +213,7 @@ def _gen_math_funcs():
         ("sin", 1),
         ("cos", 1),
         ("tanh", 1),
+        ("acos", 1),
         ("atan2", 2),
     ]
 

--- a/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToLlvm.cpp
+++ b/numba_mlir/numba_mlir/mlir_compiler/lib/pipelines/LowerToLlvm.cpp
@@ -52,6 +52,7 @@
 #include "BasePipeline.hpp"
 
 #include "numba/Compiler/PipelineRegistry.hpp"
+#include "numba/Conversion/MathExtToLibm.hpp"
 #include "numba/Conversion/UtilToLlvm.hpp"
 #include "numba/Dialect/numba_util/Dialect.hpp"
 #include "numba/Transforms/FuncUtils.hpp"
@@ -1834,6 +1835,7 @@ static void populateLowerToLlvmPipeline(mlir::OpPassManager &pm) {
   pm.addNestedPass<mlir::func::FuncOp>(mlir::createConvertMathToLLVMPass());
   pm.addNestedPass<mlir::func::FuncOp>(std::make_unique<LowerVectorOps>());
   pm.addPass(mlir::createConvertMathToLibmPass());
+  pm.addPass(numba::createMathExtToLibmPass());
   pm.addPass(numba::createUtilToLLVMPass(&getLLVMOptions));
   pm.addPass(std::make_unique<LLVMLoweringPass>());
   pm.addPass(std::make_unique<FixLLVMStructABIPass>());


### PR DESCRIPTION
* Dialect for math ops, not (yet) available in upstream `math` dialect
* Add `acos` op as example