### PR TITLE
Update to Numba 0.59

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Build Python frontend
         run: |
           cd numba_mlir
-          conda create -y -n test-env python=${{ matrix.python }} "pip>=22" numba=0.58 numpy=1.24 "setuptools<65.6" scikit-learn pytest-xdist ninja scipy pybind11 pytest "tbb>=$env:TBB_VER" "tbb-devel>=$env:TBB_VER" cmake "mkl-devel-dpcpp=2024.0.0" zlib dpcpp_win-64 level-zero-devel -c conda-forge -c intel -c numba
+          conda create -y -n test-env python=${{ matrix.python }} "pip>=22" numba=0.59.1 numpy=1.24 "setuptools<65.6" scikit-learn pytest-xdist ninja scipy pybind11 pytest "tbb>=$env:TBB_VER" "tbb-devel>=$env:TBB_VER" cmake "mkl-devel-dpcpp=2024.0.0" zlib dpcpp_win-64 level-zero-devel -c conda-forge -c intel -c numba
           conda info
           conda activate test-env
           echo "Conda prefix: $env:CONDA_PREFIX"
@@ -227,6 +227,7 @@ jobs:
           cd numba_mlir
           conda activate test-env
           python "$env:GITHUB_WORKSPACE/numba_mlir/conda-recipe/run_package_tests.py" verbose
+          python "$env:GITHUB_WORKSPACE/numba_mlir/conda-recipe/run_package_tests.py" verbose replace_parfors
 
       - name: Run offload tests
         if: false # Doesn't work
@@ -273,7 +274,7 @@ jobs:
 
         run: |
           cd numba_mlir_wheels
-          conda create -y -n wheels-test-env python=${{ matrix.python }} numba=0.58 numpy=1.24 scikit-learn pytest-xdist scipy pytest "tbb=$env:TBB_VER" cmake "mkl-devel-dpcpp=2024.0.0" dpcpp_win-64 -c conda-forge -c intel -c numba
+          conda create -y -n wheels-test-env python=${{ matrix.python }} numba=0.59.1 numpy=1.24 scikit-learn pytest-xdist scipy pytest "tbb=$env:TBB_VER" cmake "mkl-devel-dpcpp=2024.0.0" dpcpp_win-64 -c conda-forge -c intel -c numba
           conda info
           conda activate wheels-test-env
           conda list
@@ -550,7 +551,7 @@ jobs:
 
         run: |
           cd numba_mlir
-          conda create -y -n test-env python=${{ matrix.python }} "pip>=22" numba=0.58 numpy=1.24 "setuptools<65.6" scikit-learn pytest-xdist ninja scipy pybind11 pytest "tbb>=${TBB_VER}" "tbb-devel>=${TBB_VER}" cmake "mkl-devel-dpcpp=2024.0.0" zlib dpcpp_linux-64 level-zero-devel -c conda-forge -c intel -c numba
+          conda create -y -n test-env python=${{ matrix.python }} "pip>=22" numba=0.59.1 numpy=1.24 "setuptools<65.6" scikit-learn pytest-xdist ninja scipy pybind11 pytest "tbb>=${TBB_VER}" "tbb-devel>=${TBB_VER}" cmake "mkl-devel-dpcpp=2024.0.0" zlib dpcpp_linux-64 level-zero-devel -c conda-forge -c intel -c numba
           conda info
           source $CONDA/bin/activate test-env
           conda install gxx_linux-64 -c conda-forge --override-channels
@@ -573,6 +574,7 @@ jobs:
           cd numba_mlir
           source $CONDA/bin/activate test-env
           python $GITHUB_WORKSPACE/numba_mlir/conda-recipe/run_package_tests.py verbose
+          python $GITHUB_WORKSPACE/numba_mlir/conda-recipe/run_package_tests.py verbose replace_parfors
 
 
       - name: Run offload tests
@@ -623,7 +625,7 @@ jobs:
 
         run: |
           cd numba_mlir_wheels
-          conda create -y -n wheels-test-env python=${{ matrix.python }} numba=0.58 numpy=1.24 scikit-learn pytest-xdist scipy pytest tbb=${TBB_VER} cmake "mkl-devel-dpcpp=2024.0.0" dpcpp_linux-64 -c conda-forge -c intel -c numba
+          conda create -y -n wheels-test-env python=${{ matrix.python }} numba=0.59.1 numpy=1.24 scikit-learn pytest-xdist scipy pytest tbb=${TBB_VER} cmake "mkl-devel-dpcpp=2024.0.0" dpcpp_linux-64 -c conda-forge -c intel -c numba
           conda info
           source $CONDA/bin/activate wheels-test-env
           conda list

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ ninja install
 Building and testing Python package
 ```Bash
 cd numba_mlir
-conda create -n test-env python=3.9 numba=0.58 numpy=1.24 "setuptools<65.6" scikit-learn pytest-xdist ninja scipy pybind11 pytest lit tbb=2021.10.0 tbb-devel=2021.10.0 cmake "mkl-devel-dpcpp=2024.0.0" dpcpp_linux-64 level-zero-devel -c conda-forge -c intel -c numba
+conda create -n test-env python=3.11 numba=0.59.1 numpy=1.24 "setuptools<65.6" scikit-learn pytest-xdist ninja scipy pybind11 pytest lit tbb=2021.10.0 tbb-devel=2021.10.0 cmake "mkl-devel-dpcpp=2024.0.0" dpcpp_linux-64 level-zero-devel -c conda-forge -c intel -c numba
 conda activate test-env
 export LLVM_PATH=<...>/llvm-install
 export NUMBA_MLIR_USE_SYCL=ON # Optional

--- a/mlir/include/numba/Dialect/plier/PlierOps.td
+++ b/mlir/include/numba/Dialect/plier/PlierOps.td
@@ -99,6 +99,10 @@ def ConstOp : Plier_Op<"const", [Pure]> {
   let builders = [OpBuilder<(ins "::mlir::Attribute" : $val)>];
 }
 
+def UndefOp : Plier_Op<"undef", [Pure]> {
+  let results = (outs AnyType);
+}
+
 def GlobalOp : Plier_Op<"global", [Pure]> {
   let arguments = (ins StrAttr : $name);
 
@@ -269,5 +273,7 @@ def SliceGetItemOp : Plier_Op<"slice_getitem", [Pure]> {
 
   let results = (outs AnyType);
 }
+
+
 
 #endif // PLIER_OPS

--- a/numba_mlir/conda-recipe/meta.yaml
+++ b/numba_mlir/conda-recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
         - tbb-devel >=2021.6.0
         - level-zero-devel
         - ninja
-        - numba >=0.57, <0.59
+        - numba >=0.59.1, <0.60
         - pybind11
         - python
         - setuptools
@@ -40,7 +40,7 @@ requirements:
     run:
         - mkl
         - mkl-dpcpp
-        - numba >=0.57, <0.59
+        - numba >=0.59.1, <0.60
         - packaging
         - python
         - tbb >=2021.6.0

--- a/numba_mlir/conda-recipe/run_package_tests.py
+++ b/numba_mlir/conda-recipe/run_package_tests.py
@@ -31,6 +31,11 @@ def run_tests(params):
     if "verbose" in params:
         args += ["-vv"]
 
+    if "replace_parfors" not in params:
+        args += ["-k", "not replace_parfors"]
+    else:
+        args += ["-k", "replace_parfors"]
+
     print(f"INFO: nproc {np}")
 
     os.environ["NUMBA_DISABLE_PERFORMANCE_WARNINGS"] = "1"

--- a/numba_mlir/numba_mlir/mlir/inner_compiler.py
+++ b/numba_mlir/numba_mlir/mlir/inner_compiler.py
@@ -25,7 +25,6 @@ class MlirTempCompiler(CompilerBase):  # custom compiler extends from CompilerBa
         untyped_passes = dpb.define_untyped_pipeline(self.state)
         pm.passes.extend(untyped_passes.passes)
 
-        pm.add_pass(ReconstructSSA, "ssa")
         pm.add_pass(NopythonTypeInference, "nopython frontend")
         pm.add_pass(MlirBackendInner, "mlir backend")
 

--- a/numba_mlir/numba_mlir/mlir/target.py
+++ b/numba_mlir/numba_mlir/mlir/target.py
@@ -12,7 +12,7 @@ from numba.extending import typeof_impl as numba_typeof_impl
 from numba.core.typing import Context
 from numba.core.registry import CPUTarget
 from numba.core.imputils import Registry as LowerRegistry
-from numba.core.dispatcher import Dispatcher
+from numba.core.dispatcher import Dispatcher, _FunctionCompiler
 from numba.core.typing.templates import Registry as TypingRegistry
 from numba.core.typing.typeof import Purpose, _TypeofContext, _termcolor
 from numba.core.target_extension import (
@@ -244,15 +244,14 @@ class NumbaMLIRDispatcher(Dispatcher):
         py_func,
         locals={},
         targetoptions={},
-        impl_kind="direct",
         pipeline_class=compiler.Compiler,
     ):
-        super().__init__(py_func, locals, targetoptions, impl_kind, pipeline_class)
+        super().__init__(py_func, locals, targetoptions, pipeline_class)
 
         # Import locally to avoid circular module dependency
         from .compiler import dummy_compiler_pipeline
 
-        compiler_class = self._impl_kinds[impl_kind]
+        compiler_class = _FunctionCompiler
         self._dummy_compiler = compiler_class(
             py_func, self.targetdescr, targetoptions, locals, dummy_compiler_pipeline
         )

--- a/numba_mlir/numba_mlir/mlir/tests/test_numba_parfor.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_numba_parfor.py
@@ -109,6 +109,14 @@ def _gen_tests():
         "test_int_arg_pndindex",
         "test_prange_optional",
         "test_1array_control_flow",
+        "test_randoms",  # random functions are not supported
+        "test_vectorizer_fastmath_asm",  # no asm generated
+        "test_signed_vs_unsigned_vec_asm",  # no asm generated
+        "test_unsigned_refusal_to_vectorize",  # no asm generated
+        "test_prange_fastmath_check_works",  # no asm generated
+        "test_issue9256_lower_sroa_conflict",  # using variable outside of parfor
+        "test_issue9256_lower_sroa_conflict_variant1",  # using variable outside of parfor
+        "test_issue9256_lower_sroa_conflict_variant2",  # using variable outside of parfor
     }
 
     skip_tests = {
@@ -374,6 +382,15 @@ def _gen_replace_parfor_tests():
         "test_nd_parfor",
         "test_arange",
         "test_linspace",
+        "test_randoms",  # random functions are not supported
+        "test_vectorizer_fastmath_asm",  # no asm generated
+        "test_signed_vs_unsigned_vec_asm",  # no asm generated
+        "test_unsigned_refusal_to_vectorize",  # no asm generated
+        "test_prange_fastmath_check_works",  # no asm generated
+        "test_issue9256_lower_sroa_conflict",  # using variable outside of parfor
+        "test_issue9256_lower_sroa_conflict_variant1",  # using variable outside of parfor
+        "test_issue9256_lower_sroa_conflict_variant2",  # using variable outside of parfor
+        "test_allocation_hoisting",  # TODO: investigate
     }
     skip_tests = {
         "test_copy_global_for_parfor",  # flaky test

--- a/numba_mlir/setup.py
+++ b/numba_mlir/setup.py
@@ -24,7 +24,7 @@ metadata = dict(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     packages=packages,
-    install_requires=["numba>=0.57,<0.59"],
+    install_requires=["numba>=0.59.1,<0.60"],
     include_package_data=True,
 )
 


### PR DESCRIPTION
Move to Numba 0.59.1:
* Remove use of `impl_kind` from `NumbaMLIRDispatcher` as it was removed in Numba
* Add support of Numba `UNDEFINED` and lowering it to `poison`
* Skip some tests as it mostly verify asm or due to other reasons
* Remove `ReconstructSSA` pass from `MlirTempCompiler` as `ReconstructSSA` already present in untyped passes and subsequent application of it results in incorrect IR.
* Split test cases with `replace_parfor` and without it due to Numba a issue
*  Updated `setup.py` and `meta.yaml`
* Updated README