### PR TITLE
Update dpcpp packages to 2024.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
           run-post: false
           miniforge-variant: Mambaforge
           miniforge-version: latest
-          channels: intel,conda-forge
+          channels: conda-forge,intel
 
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -203,7 +203,7 @@ jobs:
       - name: Build Python frontend
         run: |
           cd numba_mlir
-          conda create -y -n test-env python=${{ matrix.python }} "pip>=22" numba=0.59.1 numpy=1.24 "setuptools<65.6" scikit-learn pytest-xdist ninja scipy pybind11 pytest "tbb>=$env:TBB_VER" "tbb-devel>=$env:TBB_VER" cmake "mkl-devel-dpcpp=2024.0.0" zlib dpcpp_win-64 level-zero-devel -c conda-forge -c intel -c numba
+          conda create -y -n test-env python=${{ matrix.python }} "pip>=22" numba=0.59.1 numpy=1.24 "setuptools<65.6" scikit-learn pytest-xdist ninja scipy pybind11 pytest "tbb>=$env:TBB_VER" "tbb-devel>=$env:TBB_VER" cmake intel::mkl intel::mkl-devel "intel::mkl-devel-dpcpp=2024.1" zlib "conda-forge::dpcpp_win-64=2024.1" level-zero-devel -c conda-forge -c numba -c intel --override-channels
           conda info
           conda activate test-env
           echo "Conda prefix: $env:CONDA_PREFIX"
@@ -234,7 +234,7 @@ jobs:
         run: |
           cd numba_mlir
           conda activate test-env
-          conda install greenlet "dpctl=0.15" "dpcpp-cpp-rt=2024.0.0" -c dppy/label/dev -c intel -c conda-forge
+          conda install greenlet "dpctl=0.18" "conda-forge::dpcpp-cpp-rt=2024.1" -c dppy/label/dev -c conda-forge -c intel
           conda list
           $env:NUMBA_MLIR_DEFAULT_DEVICE="opencl:cpu:0"
           python "$env:GITHUB_WORKSPACE/numba_mlir/conda-recipe/run_package_tests.py" verbose gpu
@@ -274,7 +274,7 @@ jobs:
 
         run: |
           cd numba_mlir_wheels
-          conda create -y -n wheels-test-env python=${{ matrix.python }} numba=0.59.1 numpy=1.24 scikit-learn pytest-xdist scipy pytest "tbb=$env:TBB_VER" cmake "mkl-devel-dpcpp=2024.0.0" dpcpp_win-64 -c conda-forge -c intel -c numba
+          conda create -y -n wheels-test-env python=${{ matrix.python }} numba=0.59.1 numpy=1.24 scikit-learn pytest-xdist scipy pytest "tbb>=$env:TBB_VER" cmake intel::mkl intel::mkl-devel "intel::mkl-devel-dpcpp=2024.1" "conda-forge::dpcpp_win-64=2024.1" -c conda-forge -c numba -c intel --override-channels
           conda info
           conda activate wheels-test-env
           conda list
@@ -314,7 +314,7 @@ jobs:
           run-post: false
           miniforge-variant: Mambaforge
           miniforge-version: latest
-          channels: intel,conda-forge
+          channels: conda-forge,intel
 
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -359,7 +359,7 @@ jobs:
           $env:CXX="cl.exe"
           $env:CC="cl.exe"
           $env:VSCMD_DEBUG = 3
-          conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c intel -c conda-forge -c numba --override-channels
+          conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c conda-forge -c numba -c intel --override-channels
           cd win-64
           ls .
           popd
@@ -522,7 +522,7 @@ jobs:
           run-post: false
           miniforge-variant: Mambaforge
           miniforge-version: latest
-          channels: intel,conda-forge
+          channels: conda-forge,intel
 
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -551,10 +551,10 @@ jobs:
 
         run: |
           cd numba_mlir
-          conda create -y -n test-env python=${{ matrix.python }} "pip>=22" numba=0.59.1 numpy=1.24 "setuptools<65.6" scikit-learn pytest-xdist ninja scipy pybind11 pytest "tbb>=${TBB_VER}" "tbb-devel>=${TBB_VER}" cmake "mkl-devel-dpcpp=2024.0.0" zlib dpcpp_linux-64 level-zero-devel -c conda-forge -c intel -c numba
+          conda create -y -n test-env python=${{ matrix.python }} "pip>=22" numba=0.59.1 numpy=1.24 "setuptools<65.6" scikit-learn pytest-xdist ninja scipy pybind11 pytest "tbb>=${TBB_VER}" "tbb-devel>=${TBB_VER}" cmake intel::mkl intel::mkl-devel "intel::mkl-devel-dpcpp=2024.1" zlib "dpcpp_linux-64=2024.1" level-zero-devel -c conda-forge -c numba -c intel --override-channels
           conda info
           source $CONDA/bin/activate test-env
-          conda install gxx_linux-64 -c conda-forge --override-channels
+          conda install gxx_linux-64 -c conda-forge
           conda list
           python -c "import numba; print('numba', numba.__version__)"
           python -c "import numpy; print(numpy.get_include())"
@@ -578,13 +578,12 @@ jobs:
 
 
       - name: Run offload tests
-        if: false # Doesn't work
         shell: bash -l {0}
 
         run: |
           cd numba_mlir
           source $CONDA/bin/activate test-env
-          conda install greenlet "dpctl=0.15" "dpcpp-cpp-rt=2024.0.0" -c dppy/label/dev -c intel -c conda-forge
+          conda install greenlet "dpctl=0.18" "conda-forge::dpcpp-cpp-rt=2024.1" -c dppy/label/dev -c conda-forge -c intel
           conda list
           export NUMBA_MLIR_DEFAULT_DEVICE=opencl:cpu:0
           python $GITHUB_WORKSPACE/numba_mlir/conda-recipe/run_package_tests.py verbose gpu
@@ -625,7 +624,7 @@ jobs:
 
         run: |
           cd numba_mlir_wheels
-          conda create -y -n wheels-test-env python=${{ matrix.python }} numba=0.59.1 numpy=1.24 scikit-learn pytest-xdist scipy pytest tbb=${TBB_VER} cmake "mkl-devel-dpcpp=2024.0.0" dpcpp_linux-64 -c conda-forge -c intel -c numba
+          conda create -y -n wheels-test-env python=${{ matrix.python }} numba=0.59.1 numpy=1.24 scikit-learn pytest-xdist scipy pytest tbb>=${TBB_VER} cmake intel::mkl intel::mkl-devel "intel::mkl-devel-dpcpp=2024.1" "conda-forge::dpcpp_linux-64=2024.1" -c conda-forge -c numba -c intel --override-channels
           conda info
           source $CONDA/bin/activate wheels-test-env
           conda list
@@ -659,7 +658,7 @@ jobs:
           run-post: false
           miniforge-variant: Mambaforge
           miniforge-version: latest
-          channels: intel,conda-forge
+          channels: conda-forge,intel
 
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -694,7 +693,7 @@ jobs:
           export LLVM_PATH=/home/runner/work/llvm-mlir/_mlir_install
           export LEVEL_ZERO_VERSION_CHECK_OFF=1
           export NUMBA_MLIR_USE_SYCL=ON
-          conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c intel -c conda-forge -c numba --override-channels || exit 1
+          conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c conda-forge -c numba -c intel --override-channels || exit 1
           cd linux-64
           ls -l --block-size=M
           popd
@@ -738,7 +737,7 @@ jobs:
           miniforge-variant: Mambaforge
           miniforge-version: latest
           channel-priority: "disabled"
-          channels: intel,conda-forge
+          channels: conda-forge,intel
 
       - name: Install anaconda-client
         run: conda install anaconda-client

--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,6 @@ _install
 
 # airspeed velocity cache
 .asv
+
+# vscode
+.vscode

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ ninja install
 Building and testing Python package
 ```Bash
 cd numba_mlir
-conda create -n test-env python=3.11 numba=0.59.1 numpy=1.24 "setuptools<65.6" scikit-learn pytest-xdist ninja scipy pybind11 pytest lit tbb=2021.10.0 tbb-devel=2021.10.0 cmake "mkl-devel-dpcpp=2024.0.0" dpcpp_linux-64 level-zero-devel -c conda-forge -c intel -c numba
+conda create -n test-env python=3.11 numba=0.59.1 numpy=1.24 "setuptools<65.6" scikit-learn pytest-xdist ninja scipy pybind11 pytest lit tbb=2021.11 tbb-devel=2021.11 cmake "intel::mkl-devel-dpcpp=2024.1" conda-forge::dpcpp_linux-64 level-zero-devel -c conda-forge -c intel -c numba --override-channels
 conda activate test-env
 export LLVM_PATH=<...>/llvm-install
 export NUMBA_MLIR_USE_SYCL=ON # Optional

--- a/numba_mlir/conda-recipe/conda_build_config.yaml
+++ b/numba_mlir/conda-recipe/conda_build_config.yaml
@@ -5,5 +5,4 @@ numpy:
 pin_run_as_build:
   mkl: x.x
   mkl-dpcpp: x.x
-  dpcpp-cpp-rt: x.x
-  dpcpp_cpp_rt: x.x
+  conda-forge::dpcpp-cpp-rt: x.x

--- a/numba_mlir/conda-recipe/meta.yaml
+++ b/numba_mlir/conda-recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set dpcpp_version = ">=2023.1" %}
+{% set dpcpp_version = ">=2024.1" %}
 
 package:
     name: numba-mlir
@@ -17,20 +17,19 @@ build:
 
 requirements:
     build:
-        - {{ compiler('cxx') }}
-        - {{ compiler('dpcpp') }}  =2024.0.0  # [not osx]
+        - conda-forge::{{ compiler('cxx') }}
+        - conda-forge::{{ compiler('dpcpp') }}  =2024.1  # [not osx]
         - sysroot_linux-64 >=2.17  # [linux]
-    host:
         - cmake >=3.23
-        - mkl-devel {{ dpcpp_version }}
-        - mkl-devel-dpcpp {{ dpcpp_version }}
-        - mkl {{ dpcpp_version }}
-        - mkl-dpcpp {{ dpcpp_version }}
-        - dpcpp-cpp-rt {{ dpcpp_version }}
-        - dpcpp_cpp_rt {{ dpcpp_version }}
+        - ninja
+    host:
+        - intel::mkl-devel {{ dpcpp_version }}
+        - intel::mkl-devel-dpcpp {{ dpcpp_version }}
+        - intel::mkl {{ dpcpp_version }}
+        - intel::mkl-dpcpp {{ dpcpp_version }}
+        - conda-forge::dpcpp-cpp-rt {{ dpcpp_version }}
         - tbb-devel >=2021.6.0
         - level-zero-devel
-        - ninja
         - numba >=0.59.1, <0.60
         - pybind11
         - python
@@ -38,8 +37,8 @@ requirements:
         - wheel
         - zlib
     run:
-        - mkl
-        - mkl-dpcpp
+        - intel::mkl
+        - intel::mkl-dpcpp {{ dpcpp_version }}
         - numba >=0.59.1, <0.60
         - packaging
         - python

--- a/numba_mlir/numba_mlir/math_runtime/CMakeLists.txt
+++ b/numba_mlir/numba_mlir/math_runtime/CMakeLists.txt
@@ -26,9 +26,6 @@ if(NUMBA_MLIR_USE_MKL)
     if (NOT DEFINED(MKL_THREADING))
         set(MKL_THREADING tbb_thread)
     endif()
-    if (NOT DEFINED(MKL_LINK))
-        set(MKL_LINK sdl)
-    endif()
 
     find_package(MKL CONFIG REQUIRED)
 

--- a/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
+++ b/numba_mlir/numba_mlir/mlir/tests/test_gpu.py
@@ -63,7 +63,7 @@ def _to_device_kernel_args(args):
         else:
             order = "K"
         return dpt.asarray(
-            obj=args,
+            args,
             dtype=args.dtype,
             device=_def_device,
             copy=None,
@@ -1438,7 +1438,7 @@ def _from_host(arr, buffer):
     else:
         order = "K"
     return dpt.asarray(
-        obj=arr,
+        arr,
         dtype=arr.dtype,
         device=_def_device,
         copy=True,

--- a/scripts/bench-env-linux.yml
+++ b/scripts/bench-env-linux.yml
@@ -9,7 +9,7 @@ dependencies:
   - asv=0.6
   - numba-mlir
   - dpctl
-  - dpcpp_linux-64
+  - dpcpp_linux-64 = 2024.1
   - icc_rt
   - intel::numpy
   - py-cpuinfo

--- a/scripts/core-env-linux.yml
+++ b/scripts/core-env-linux.yml
@@ -9,5 +9,5 @@ dependencies:
   - lit
   - zlib
   - gxx_linux-64
-  - tbb-devel =2021.10.0
+  - tbb-devel >=2021.10.0
   - level-zero-devel


### PR DESCRIPTION
Update dpcpp packages to 2024.1:
* Updated packages
* Change channels priority to avoid using `intel` channel
* Force `conda-forge` channel for `dpcpp` since version from `intel` channel fails on conda package step
* Force `intel` channel fir `mkl-devel-dpcpp`
* Update `dpctl` to `0.18` version  
* Make `tbb` version to be  `>=2021.10`
* Fix `asarray` usage in gpu tests according to new API
* Remove `MKL_LINK sdl` since it is not supported by dpcpp. Default value for `MKL_LINK` is `dynamic`.
* Re-enable gpu tests
* Update README 