### PR TITLE
Updating intel packages to 2024.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -680,7 +680,7 @@ jobs:
           export LEVEL_ZERO_VERSION_CHECK_OFF=1
           export NUMBA_MLIR_USE_SYCL=ON
           # conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c conda-forge -c numba -c https://software.repos.intel.com/python/conda/ || exit 1
-          conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c https://software.repos.intel.com/python/conda/ -c conda-forge -c numba || exit 1
+          conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c https://software.repos.intel.com/python/conda/ -c conda-forge -c numba --override-channels || exit 1
           cd linux-64
           ls -l --block-size=M
           popd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -358,7 +358,7 @@ jobs:
           $env:CXX="cl.exe"
           $env:CC="cl.exe"
           $env:VSCMD_DEBUG = 3
-          conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c conda-forge -c numba -c https://software.repos.intel.com/python/conda/
+          conda conda-build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c https://software.repos.intel.com/python/conda/ -c conda-forge -c numba --override-channels
           cd win-64
           ls .
           popd
@@ -679,8 +679,8 @@ jobs:
           export LLVM_PATH=/home/runner/work/llvm-mlir/_mlir_install
           export LEVEL_ZERO_VERSION_CHECK_OFF=1
           export NUMBA_MLIR_USE_SYCL=ON
-          # conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c conda-forge -c numba -c https://software.repos.intel.com/python/conda/ || exit 1
-          conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c https://software.repos.intel.com/python/conda/ -c conda-forge -c numba --override-channels || exit 1
+          # conda conda-build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c conda-forge -c numba -c https://software.repos.intel.com/python/conda/ || exit 1
+          conda conda-build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c https://software.repos.intel.com/python/conda/ -c conda-forge -c numba --override-channels || exit 1
           cd linux-64
           ls -l --block-size=M
           popd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -358,7 +358,7 @@ jobs:
           $env:CXX="cl.exe"
           $env:CC="cl.exe"
           $env:VSCMD_DEBUG = 3
-          conda conda-build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c https://software.repos.intel.com/python/conda/ -c conda-forge -c numba --override-channels
+          conda build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c https://software.repos.intel.com/python/conda/ -c conda-forge -c numba --override-channels
           cd win-64
           ls .
           popd
@@ -679,8 +679,8 @@ jobs:
           export LLVM_PATH=/home/runner/work/llvm-mlir/_mlir_install
           export LEVEL_ZERO_VERSION_CHECK_OFF=1
           export NUMBA_MLIR_USE_SYCL=ON
-          # conda conda-build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c conda-forge -c numba -c https://software.repos.intel.com/python/conda/ || exit 1
-          conda conda-build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c https://software.repos.intel.com/python/conda/ -c conda-forge -c numba --override-channels || exit 1
+          # conda build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c conda-forge -c numba -c https://software.repos.intel.com/python/conda/ || exit 1
+          conda build --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c https://software.repos.intel.com/python/conda/ -c conda-forge -c numba --override-channels || exit 1
           cd linux-64
           ls -l --block-size=M
           popd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,7 +229,7 @@ jobs:
           python "$env:GITHUB_WORKSPACE/numba_mlir/conda-recipe/run_package_tests.py" verbose replace_parfors
 
       - name: Run offload tests
-        if: false # Doesn't work
+        # if: false # Doesn't work
         run: |
           cd numba_mlir
           conda activate test-env

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,7 +229,7 @@ jobs:
           python "$env:GITHUB_WORKSPACE/numba_mlir/conda-recipe/run_package_tests.py" verbose replace_parfors
 
       - name: Run offload tests
-        # if: false # Doesn't work
+        if: false # Doesn't work
         run: |
           cd numba_mlir
           conda activate test-env

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -680,7 +680,7 @@ jobs:
           export LEVEL_ZERO_VERSION_CHECK_OFF=1
           export NUMBA_MLIR_USE_SYCL=ON
           # conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c conda-forge -c numba -c https://software.repos.intel.com/python/conda/ || exit 1
-          conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} || exit 1
+          conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c https://software.repos.intel.com/python/conda/ -c conda-forge -c numba || exit 1
           cd linux-64
           ls -l --block-size=M
           popd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -358,7 +358,7 @@ jobs:
           $env:CXX="cl.exe"
           $env:CC="cl.exe"
           $env:VSCMD_DEBUG = 3
-          conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c conda-forge -c numba -c https://software.repos.intel.com/python/conda/ --override-channels
+          conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c conda-forge -c numba -c https://software.repos.intel.com/python/conda/
           cd win-64
           ls .
           popd
@@ -568,7 +568,6 @@ jobs:
 
 
       - name: Run offload tests
-        if: false # Re-enable after packages update to 2024.2
         shell: bash -l {0}
 
         run: |
@@ -680,7 +679,8 @@ jobs:
           export LLVM_PATH=/home/runner/work/llvm-mlir/_mlir_install
           export LEVEL_ZERO_VERSION_CHECK_OFF=1
           export NUMBA_MLIR_USE_SYCL=ON
-          conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c conda-forge -c numba -c https://software.repos.intel.com/python/conda/ --override-channels || exit 1
+          # conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} -c conda-forge -c numba -c https://software.repos.intel.com/python/conda/ || exit 1
+          conda mambabuild --output-folder=. ../numba_mlir/conda-recipe --python=${{ matrix.python }} || exit 1
           cd linux-64
           ls -l --block-size=M
           popd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,10 +201,10 @@ jobs:
           ./vcvars.ps1
           popd
           cd numba_mlir
-          conda create -y -n test-env python=${{ matrix.python }} "dpcpp_win-64=2024.1" --file ../scripts/numba-mlir.env -c conda-forge
+          conda create -y -n test-env python=${{ matrix.python }} --file ../scripts/numba-mlir.env -c conda-forge
           conda info
           conda activate test-env
-          conda install --file ../scripts/mkl.env -c https://software.repos.intel.com/python/conda/
+          conda install dpcpp_win-64=2024.2 --file ../scripts/mkl.env -c https://software.repos.intel.com/python/conda/
           echo "Conda prefix: $env:CONDA_PREFIX"
           echo "Patch broken Windows MKLConfig.cmake"
           cp "$env:GITHUB_WORKSPACE/numba_mlir/conda-recipe/MKLConfig.cmake" "$env:CONDA_PREFIX/Library/lib/cmake/mkl" -Force
@@ -277,10 +277,10 @@ jobs:
 
         run: |
           cd numba_mlir_wheels
-          conda create -y -n wheels-test-env python=${{ matrix.python }} "dpcpp_win-64=2024.1" --file ../scripts/numba-mlir.env -c conda-forge
+          conda create -y -n wheels-test-env python=${{ matrix.python }} --file ../scripts/numba-mlir.env -c conda-forge
           conda info
           conda activate wheels-test-env
-          conda install --file ../scripts/mkl.env -c https://software.repos.intel.com/python/conda/
+          conda install dpcpp_win-64=2024.2 --file ../scripts/mkl.env -c https://software.repos.intel.com/python/conda/
           conda list
           ls .
           ls *.whl | Foreach-Object { pip install $_.FullName }
@@ -540,10 +540,10 @@ jobs:
 
         run: |
           cd numba_mlir
-          conda create -y -n test-env python=${{ matrix.python }} "dpcpp_linux-64=2024.1" --file ../scripts/numba-mlir.env -c conda-forge
+          conda create -y -n test-env python=${{ matrix.python }} --file ../scripts/numba-mlir.env -c conda-forge
           conda info
           source $CONDA/bin/activate test-env
-          conda install --file ../scripts/mkl.env -c https://software.repos.intel.com/python/conda/
+          conda install dpcpp_linux-64=2024.2 --file ../scripts/mkl.env -c https://software.repos.intel.com/python/conda/
           conda install gxx_linux-64 -c conda-forge
           conda list
           python -c "import numba; print('numba', numba.__version__)"
@@ -615,10 +615,10 @@ jobs:
 
         run: |
           cd numba_mlir_wheels
-          conda create -y -n wheels-test-env python=${{ matrix.python }} "dpcpp_linux-64=2024.1" --file ../scripts/numba-mlir.env -c conda-forge
+          conda create -y -n wheels-test-env python=${{ matrix.python }} --file ../scripts/numba-mlir.env -c conda-forge
           conda info
           source $CONDA/bin/activate wheels-test-env
-          conda install --file ../scripts/mkl.env -c https://software.repos.intel.com/python/conda/
+          conda install dpcpp_linux-64=2024.2 --file ../scripts/mkl.env -c https://software.repos.intel.com/python/conda/
           conda list
           pip install *.whl
           python $GITHUB_WORKSPACE/numba_mlir/conda-recipe/run_package_tests.py verbose smoke

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ ninja install
 Building and testing Python package
 ```Bash
 cd numba_mlir
-conda create -n test-env python=3.11 dpcpp_linux-64=2024.2 --file ../scripts/numba-mlir.env -c conda-forge
+conda create -n test-env python=3.11 --file ../scripts/numba-mlir.env -c conda-forge
 conda activate test-env
-conda install --file ../scripts/mkl.env -c https://software.repos.intel.com/python/conda/
+conda install dpcpp_linux-64=2024.2 --file ../scripts/mkl.env -c https://software.repos.intel.com/python/conda/
 export LLVM_PATH=<...>/llvm-install
 export NUMBA_MLIR_USE_SYCL=ON # Optional
 python setup.py develop

--- a/numba_mlir/conda-recipe/conda_build_config.yaml
+++ b/numba_mlir/conda-recipe/conda_build_config.yaml
@@ -3,6 +3,6 @@ cxx_compiler:
 numpy:
   - 1.23
 pin_run_as_build:
+  https://software.repos.intel.com/python/conda/::dpcpp-cpp-rt: x.x
   mkl: x.x
   mkl-dpcpp: x.x
-  conda-forge::dpcpp-cpp-rt: x.x

--- a/numba_mlir/conda-recipe/meta.yaml
+++ b/numba_mlir/conda-recipe/meta.yaml
@@ -18,6 +18,7 @@ build:
 requirements:
     build:
         - conda-forge::{{ compiler('cxx') }}
+        - https://software.repos.intel.com/python/conda/::dpcpp-cpp-rt {{ dpcpp_version }}
         - https://software.repos.intel.com/python/conda/::{{ compiler('dpcpp') }}  =2024.2  # [not osx]
         - sysroot_linux-64 >=2.17  # [linux]
         - cmake >=3.23
@@ -27,7 +28,7 @@ requirements:
         - https://software.repos.intel.com/python/conda/::mkl-devel-dpcpp {{ dpcpp_version }}
         - https://software.repos.intel.com/python/conda/::mkl {{ dpcpp_version }}
         - https://software.repos.intel.com/python/conda/::mkl-dpcpp {{ dpcpp_version }}
-        - conda-forge::dpcpp-cpp-rt {{ dpcpp_version }}
+        - https://software.repos.intel.com/python/conda/::dpcpp-cpp-rt {{ dpcpp_version }}
         - tbb-devel >=2021.6.0
         - level-zero-devel
         - numba >=0.59.1, <0.60

--- a/numba_mlir/conda-recipe/meta.yaml
+++ b/numba_mlir/conda-recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set dpcpp_version = ">=2024.1" %}
+{% set dpcpp_version = ">=2024.2" %}
 
 package:
     name: numba-mlir
@@ -18,15 +18,15 @@ build:
 requirements:
     build:
         - conda-forge::{{ compiler('cxx') }}
-        - conda-forge::{{ compiler('dpcpp') }}  =2024.1  # [not osx]
+        - https://software.repos.intel.com/python/conda/::{{ compiler('dpcpp') }}  =2024.2  # [not osx]
         - sysroot_linux-64 >=2.17  # [linux]
         - cmake >=3.23
         - ninja
     host:
-        - intel::mkl-devel {{ dpcpp_version }}
-        - intel::mkl-devel-dpcpp {{ dpcpp_version }}
-        - intel::mkl {{ dpcpp_version }}
-        - intel::mkl-dpcpp {{ dpcpp_version }}
+        - https://software.repos.intel.com/python/conda/::mkl-devel {{ dpcpp_version }}
+        - https://software.repos.intel.com/python/conda/::mkl-devel-dpcpp {{ dpcpp_version }}
+        - https://software.repos.intel.com/python/conda/::mkl {{ dpcpp_version }}
+        - https://software.repos.intel.com/python/conda/::mkl-dpcpp {{ dpcpp_version }}
         - conda-forge::dpcpp-cpp-rt {{ dpcpp_version }}
         - tbb-devel >=2021.6.0
         - level-zero-devel
@@ -37,8 +37,8 @@ requirements:
         - wheel
         - zlib
     run:
-        - intel::mkl
-        - intel::mkl-dpcpp {{ dpcpp_version }}
+        - https://software.repos.intel.com/python/conda/::mkl
+        - https://software.repos.intel.com/python/conda/::mkl-dpcpp {{ dpcpp_version }}
         - numba >=0.59.1, <0.60
         - packaging
         - python

--- a/scripts/bench-env-linux.yml
+++ b/scripts/bench-env-linux.yml
@@ -9,7 +9,7 @@ dependencies:
   - asv=0.6
   - numba-mlir
   - dpctl
-  - dpcpp_linux-64 = 2024.1
+  - dpcpp_linux-64 = 2024.2
   - icc_rt
   - https://software.repos.intel.com/python/conda/::numpy
   - py-cpuinfo

--- a/scripts/mkl.env
+++ b/scripts/mkl.env
@@ -1,3 +1,3 @@
 mkl
 mkl-devel
-mkl-devel-dpcpp=2024.1
+mkl-devel-dpcpp=2024.2


### PR DESCRIPTION
* Update Intel packages to version 2024.2
* Use `dpcpp` from `https://software.repos.intel.com/python/conda/`
* Re-enable offload tests for linux
* Replace `mambabuild` with `conda-build`